### PR TITLE
removed: dev tools by default

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -18,8 +18,6 @@ const createWindow = () => {
    })
 
    mainWindow.loadFile("src/main_menu.html")
-
-   mainWindow.webContents.openDevTools()
 }
 
 // This method will be called when Electron has finished


### PR DESCRIPTION
This PR removes the developer tools popup by default. Developer tools can still be activated through View > Toggle Developer Tools.