### PR TITLE
15 go tab tests added MUST READ

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ permissions:
 jobs:
   # Run tests before building (only once on Ubuntu)
   test:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
 
     steps:
       - name: Check out Git repository
@@ -25,7 +25,7 @@ jobs:
         run: npm ci # Ensures exact dependencies from package-lock.json
 
       # Run Mocha tests before building
-      - name: Run electron-mocha tests
+      - name: Run Tests
         run: npm test
         env:
           NODE_ENV: test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,7 @@ jobs:
 
       # Run Mocha tests before building
       - name: Run Tests
+        # Add more tests for your preferred testing framework
         run: npm test
         env:
           NODE_ENV: test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,19 +22,19 @@ jobs:
 
       # Install dependencies (including dev dependencies)
       - name: Install dependencies
-        run: npm ci  # Ensures exact dependencies from package-lock.json
+        run: npm ci # Ensures exact dependencies from package-lock.json
 
       # Run Mocha tests before building
-      - name: Run Mocha tests 
-        run: npx mocha
+      - name: Run electron-mocha tests
+        run: npm test
         env:
           NODE_ENV: test
 
   release:
-    needs: test  # Ensures this job runs only if 'test' passes
+    needs: test # Ensures this job runs only if 'test' passes
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest, windows-latest]  # Run build on three platforms
+        os: [macos-latest, ubuntu-latest, windows-latest] # Run build on three platforms
 
     runs-on: ${{ matrix.os }}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "KeepOrDelete",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "KeepOrDelete",
-      "version": "0.1.0",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
         "electron-squirrel-startup": "^1.0.1"
@@ -21,9 +21,10 @@
         "@electron-forge/plugin-fuses": "^7.6.0",
         "@electron/fuses": "^1.8.0",
         "@types/mime": "3.0.0",
-        "chai": "^5.1.2",
+        "chai": "^4.3.6",
         "electron": "34.0.0",
         "electron-builder": "25.1.8",
+        "electron-mocha": "^13.1.0",
         "mime": "3.0.0",
         "mocha": "^11.1.0"
       }
@@ -1918,13 +1919,13 @@
       }
     },
     "node_modules/assertion-error": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
-      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=12"
+        "node": "*"
       }
     },
     "node_modules/astral-regex": {
@@ -2343,20 +2344,22 @@
       }
     },
     "node_modules/chai": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-5.1.2.tgz",
-      "integrity": "sha512-aGtmf24DW6MLHHG5gCx4zaI3uBq3KRtxeVs0DjFH6Z0rDNbsvTxFASFvdj79pxjxZ8/5u3PIiN3IwEIQkiiuPw==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.6.tgz",
+      "integrity": "sha512-bbcp3YfHCUzMOvKqsztczerVgBKSsEijCySNlHHbX3VG1nskvqjz5Rfso1gGwD6w6oOV3eI60pKuMOV5MV7p3Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "assertion-error": "^2.0.1",
-        "check-error": "^2.1.1",
-        "deep-eql": "^5.0.1",
-        "loupe": "^3.1.0",
-        "pathval": "^2.0.0"
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^3.0.1",
+        "get-func-name": "^2.0.0",
+        "loupe": "^2.3.1",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.0.5"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=4"
       }
     },
     "node_modules/chalk": {
@@ -2377,13 +2380,16 @@
       }
     },
     "node_modules/check-error": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
-      "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
+      "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "get-func-name": "^2.0.2"
+      },
       "engines": {
-        "node": ">= 16"
+        "node": "*"
       }
     },
     "node_modules/chokidar": {
@@ -2944,13 +2950,16 @@
       }
     },
     "node_modules/deep-eql": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
-      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "type-detect": "^4.0.0"
+      },
       "engines": {
-        "node": ">=6"
+        "node": ">=0.12"
       }
     },
     "node_modules/defaults": {
@@ -3673,6 +3682,52 @@
         "node": ">=10"
       }
     },
+    "node_modules/electron-mocha": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/electron-mocha/-/electron-mocha-13.1.0.tgz",
+      "integrity": "sha512-n/PxV2Jv3mGiqFwoYWvzsjBxNXzuLqkfgxeJtjrrLpuYN/9VaJP98FUsd4GRKFFerD3Q1KihqNCaLXXEER2j1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-colors": "^4.1.1",
+        "electron-window": "^0.8.0",
+        "mocha": "^11.0.1",
+        "which": "^5.0.0",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "electron-mocha": "bin/electron-mocha"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      }
+    },
+    "node_modules/electron-mocha/node_modules/isexe": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
+      "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/electron-mocha/node_modules/which": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-5.0.0.tgz",
+      "integrity": "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^3.1.1"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
     "node_modules/electron-publish": {
       "version": "25.1.7",
       "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-25.1.7.tgz",
@@ -3740,6 +3795,16 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
+    },
+    "node_modules/electron-window": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/electron-window/-/electron-window-0.8.1.tgz",
+      "integrity": "sha512-W1i9LfnZJozk3MXE8VgsL2E5wOUHSgyCvcg1H2vQQjj+gqhO9lVudgY3z3SF7LJAmi+0vy3CJkbMqsynWB49EA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-electron-renderer": "^2.0.0"
+      }
     },
     "node_modules/electron-winstaller": {
       "version": "5.4.0",
@@ -4588,6 +4653,16 @@
         "get-folder-size": "bin/get-folder-size"
       }
     },
+    "node_modules/get-func-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/get-installed-path": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/get-installed-path/-/get-installed-path-2.1.1.tgz",
@@ -5217,6 +5292,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-electron-renderer": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-electron-renderer/-/is-electron-renderer-2.0.1.tgz",
+      "integrity": "sha512-pRlQnpaCFhDVPtkXkP+g9Ybv/CjbiQDjnKFQTEjpBfDKeV6dRDBczuFRDpM6DVfk2EjpMS8t5kwE5jPnqYl3zA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -5671,11 +5753,14 @@
       }
     },
     "node_modules/loupe": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.3.tgz",
-      "integrity": "sha512-kkIp7XSkP78ZxJEsSxW3712C6teJVoeHHwgo9zJ380de7IYyJ2ISlxojcH2pC5OFLewESmnRi/+XCDIEEVyoug==",
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
+      "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "get-func-name": "^2.0.1"
+      }
     },
     "node_modules/lowercase-keys": {
       "version": "2.0.0",
@@ -6712,13 +6797,13 @@
       }
     },
     "node_modules/pathval": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.0.tgz",
-      "integrity": "sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">= 14.16"
+        "node": "*"
       }
     },
     "node_modules/pe-library": {
@@ -8068,6 +8153,16 @@
       "license": "WTFPL",
       "dependencies": {
         "utf8-byte-length": "^1.0.1"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/type-fest": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "make": "electron-forge make",
     "publish": "electron-forge publish",
     "lint": "echo \"No linting configured\"",
-    "test": "mocha"
+    "test": "electron-mocha --renderer test/*.js"
   },
   "build": {
     "linux": {
@@ -29,11 +29,12 @@
     "@electron-forge/plugin-auto-unpack-natives": "^7.6.0",
     "@electron-forge/plugin-fuses": "^7.6.0",
     "@electron/fuses": "^1.8.0",
-    "chai": "^5.1.2",
+    "@types/mime": "3.0.0",
+    "chai": "^4.3.6",
     "electron": "34.0.0",
     "electron-builder": "25.1.8",
+    "electron-mocha": "^13.1.0",
     "mime": "3.0.0",
-    "@types/mime": "3.0.0",
     "mocha": "^11.1.0"
   },
   "keywords": [],

--- a/test/main_menu.test.js
+++ b/test/main_menu.test.js
@@ -1,6 +1,6 @@
 const { expect } = require('chai');
 
-/*Unit testing for Go Button
+/*Unit testing for Go Button 
 1) Make sure pop up works if no directory is selected
 2) Make sure path is properly sent to keep_or_delete page*/
 

--- a/test/main_menu.test.js
+++ b/test/main_menu.test.js
@@ -1,0 +1,73 @@
+const { expect } = require('chai');
+
+/*Unit testing for Go Button
+1) Make sure pop up works if no directory is selected
+2) Make sure path is properly sent to keep_or_delete page*/
+
+/*Couldn't test window.location.href because electron-mocha uses that to control the testing enviorment
+ Must use stubs to replicate the behaviour of navigation.*/
+describe('Go Button Functionality', function () {
+  // Variables to capture navigation attempts.
+  let navigateCalled;
+  let navigateUrl;
+
+  beforeEach(function () {
+    /*Creating a minimal DOM sample to simulate
+    the environment of a our main_menu page.
+    DOM = Document Object Model 
+    fake path = /src/main_menu.js*/
+
+    document.body.innerHTML = `
+      <div id="filepath">/src/main_menu.js</div>
+      <button id="goButton">Go</button>
+    `;
+
+    // Reset our navigation stub variables and alert message.
+    navigateCalled = false;
+    navigateUrl = '';
+
+    window.alertMessage = '';
+    window.alert = function(message) {
+      window.alertMessage = message;
+    };
+
+    // Define our stub navigation function.
+    function navigateStub(url) {
+      navigateCalled = true;
+      navigateUrl = url;
+    }
+
+    // Functionality for main_menu.js 
+    document.getElementById("goButton").addEventListener("click", () => {
+        const currentDir = document.getElementById("filepath").innerText.trim();
+        if (!currentDir || currentDir === "No directory selected") {
+          alert("Please select a directory first.");
+          return;
+        }
+        // Navigate to the keep or delete page
+        // window.location.href = "./breadNbutter/keep_or_delete.html";
+        navigateStub("./breadNbutter/keep_or_delete.html");
+      });
+    });
+
+    // Act Arrange & Assert
+  it('Go to keep_or_delete page when path is selected', function () {
+    document.getElementById("goButton").click();
+    expect(navigateCalled).to.be.true;
+    expect(navigateUrl).to.equal("./breadNbutter/keep_or_delete.html");
+  });
+
+  it('shows an alert if the path is an empty string', function () {
+    document.getElementById("filepath").innerText = "";
+    document.getElementById("goButton").click();
+    expect(window.alertMessage).to.equal("Please select a directory first.");
+    expect(navigateCalled).to.be.false;
+  });
+
+  it('shows an alert if no valid directory is selected', function () {
+    document.getElementById("filepath").innerText = "No directory selected";
+    document.getElementById("goButton").click();
+    expect(window.alertMessage).to.equal("Please select a directory first.");
+    expect(navigateCalled).to.be.false;
+  });
+});

--- a/test/main_menu.test.js
+++ b/test/main_menu.test.js
@@ -64,10 +64,18 @@ describe('Go Button Functionality', function () {
     expect(navigateCalled).to.be.false;
   });
 
+  it('shows an alert if the path is null', function () {
+    document.getElementById("filepath").innerText = null;
+    document.getElementById("goButton").click();
+    expect(window.alertMessage).to.equal("Please select a directory first.");
+    expect(navigateCalled).to.be.false;
+  });
+
   it('shows an alert if no valid directory is selected', function () {
     document.getElementById("filepath").innerText = "No directory selected";
     document.getElementById("goButton").click();
     expect(window.alertMessage).to.equal("Please select a directory first.");
     expect(navigateCalled).to.be.false;
   });
+
 });


### PR DESCRIPTION
<img width="426" alt="Screenshot 2025-02-07 at 11 21 48 PM" src="https://github.com/user-attachments/assets/c77c98d9-b4d9-424e-baa7-a9993bd0f1e6" />

### Tests

Created some unit tests for the Go button functionality. 

1. Makes sure file path is correctly navigated to the keep or delete page.
2. Makes sure if no directory is selected then the pop up message is displayed.
<img width="370" alt="Screenshot 2025-02-07 at 11 22 12 PM" src="https://github.com/user-attachments/assets/a1498a10-88b3-42c2-bf07-be9806140ab3" />

### electron-mocha
Mocha has a testing framework specifically for Electron. I believe this is the best way to test our application. I ran into many problems trying to test things using Mocha because it is tailored more towards web development. **_electron-mocha_** brings all of the functionality of mocha to the desktop application.  

In order to test properly we must use the command:  electron-mocha --renderer test/*.js **_Run tests in renderer process_** 
However, I set this to _npm test_ for simplicity. 

Link: [https://www.npmjs.com/package/electron-mocha](url)


<img width="276" alt="Screenshot 2025-02-07 at 11 22 45 PM" src="https://github.com/user-attachments/assets/605b1982-bf0f-490e-aa28-93035c72e2a5" />

### NPM Install
You must run npm install after this is merged. I've also changed the version of chai due to complications with using electron-mocha. There was some errors in regards to ES modules vs CommonJS. Took me hours to figure this out but chai@4.3.6 version supports both of these types to work in unison. If you refer to picture 1, you can see the electron-mocha command runs the tests for main_menu.test.js as well as sample.js successfully. 


<img width="294" alt="Screenshot 2025-02-07 at 11 41 20 PM" src="https://github.com/user-attachments/assets/39b5bca0-da1b-44f5-b8aa-880f3702bc77" />

### CI/CD
Here, I'm changing the test command in the .yml file to npm test as this would be the call needed for testing in the future. npx mocha **_will not_** test this properly.  _(refer to picture 2)_. I tried changing this in the Sprint 1 branch so the build would stop failing. However, I decided to revert the change and wait for the team to review this pull request and make the changes while everyone is aware. (Not trying to break anything). 

![spongebob-tired-squidward-face-headache-vtc8t4ecz6hwwapq](https://github.com/user-attachments/assets/386cc064-18f2-4df2-a9f8-bcc30898aa7d)


