### PR TITLE
Deletefile

### DIFF
--- a/src/breadNbutter/keep_or_delete.html
+++ b/src/breadNbutter/keep_or_delete.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html>
+
 <head>
    <meta charset="UTF-8" />
    <!-- Content Security Policy settings as before -->
@@ -9,6 +10,7 @@
    <title>KeepOrDelete</title>
 </head>
 <!-- Here u can add other tabs and compnents for display-->
+
 <body>
    <h1>KeepOrDelete</h1>
    <div id="dirDisplay">
@@ -16,14 +18,16 @@
       <div id="previewContainer"></div>
    </div>
 
-   <button id="backButton">Change Directory</button> 
+   <button id="backButton">Change Directory</button>
    <p id="currentItem"></p>
 
    <div class="button-container">
-      <button id="prevButton">Previous</button> 
-      <button id="nextButton">Next</button> 
+      <button id="prevButton">Previous</button>
+      <button id="deleteButton">Delete</button>
+      <button id="nextButton">Next</button>
    </div>
-   
+
 </body>
 <script src="./keep_or_delete.js"></script>
+
 </html>

--- a/src/breadNbutter/keep_or_delete.js
+++ b/src/breadNbutter/keep_or_delete.js
@@ -1,3 +1,6 @@
+//const path = require("node:path");
+//const fs = require("fs");
+
 window.onload = async function () {
     let files = [];
     let currentIndex = 0;
@@ -29,10 +32,26 @@ window.onload = async function () {
         window.location.href = "../main_menu.html";
     });
 
+    document.getElementById("deleteButton").addEventListener("click", async () => {
+        const filePath = files[currentIndex];
+        try {
+            const result = await window.file.deleteFile(filePath);
+
+            if (result.success) {
+                alert("File deleted successfully!");
+            } else {
+                alert("Error: " + result.message);
+            }
+        } catch (error) {
+            console.error("Error deleting file:", error);
+            alert("Error deleting file: " + error.message);
+        }
+    });
+
     // Go through files in directory +1
     document.getElementById("nextButton").addEventListener("click", () => {
         if (files.length > 0) {
-            if(currentIndex < files.length - 1){
+            if (currentIndex < files.length - 1) {
                 currentIndex = (currentIndex + 1);
                 displayFile(files[currentIndex]);
             }
@@ -44,7 +63,7 @@ window.onload = async function () {
     // Go through files in directory - 1
     document.getElementById("prevButton").addEventListener("click", () => {
         if (files.length > 0) {
-            if(currentIndex > 0) {
+            if (currentIndex > 0) {
                 currentIndex = (currentIndex - 1);
                 displayFile(files[currentIndex]);
             }
@@ -52,7 +71,7 @@ window.onload = async function () {
                 alert("No previous files selected Directory")
             }
         }
-        
+
     });
 
     function displayFile(filename) {

--- a/src/breadNbutter/keep_or_delete.js
+++ b/src/breadNbutter/keep_or_delete.js
@@ -32,13 +32,14 @@ window.onload = async function () {
         window.location.href = "../main_menu.html";
     });
 
-    document.getElementById("deleteButton").addEventListener("click", async () => {
-        const filePath = files[currentIndex];
+    document.getElementById("deleteButton").addEventListener("click", async () => { //gets the html element containing the button for delete
+        const filePath = files[currentIndex]; //gets the current index, in the array of files that the user selected
         try {
-            const result = await window.file.deleteFile(filePath);
+            const result = await window.file.deleteFile(filePath); //calls the preload.js and invokes method that is contained in context
+            // - bridge but actually exists at line 52 of index.js
 
-            if (result.success) {
-                alert("File deleted successfully!");
+            if (result.success) { //success is a built in boolean callback
+                alert("File deleted successfully!"); //THIS SHOULD GET REMOVED EVENTUALLY, IT IS JUST FOR DEBUGGING TO KNOW WHETHER IT WORKED OR NOT 
             } else {
                 alert("Error: " + result.message);
             }
@@ -79,23 +80,23 @@ window.onload = async function () {
         refreshPreview(filename)
     }
 
-   function refreshPreview(filename) {
-      var container = document.getElementById("previewContainer");
+    function refreshPreview(filename) {
+        var container = document.getElementById("previewContainer");
 
-      const mimeType = window.file.getMimeType(filename);
+        const mimeType = window.file.getMimeType(filename);
 
-      console.log(`${filename} has MIME type ${mimeType}.`);
+        console.log(`${filename} has MIME type ${mimeType}.`);
 
-      if (mimeType != null && mimeType.startsWith("text/")) {
-         var fileContents = window.file.getFileContents(filename).replaceAll("<", "&lt;");
+        if (mimeType != null && mimeType.startsWith("text/")) {
+            var fileContents = window.file.getFileContents(filename).replaceAll("<", "&lt;");
 
-         // Escape HTML tags so they aren't interpreted as actual HTML.
-         fileContents.replaceAll("<", "&lt;");
+            // Escape HTML tags so they aren't interpreted as actual HTML.
+            fileContents.replaceAll("<", "&lt;");
 
-         // <pre> tag displays preformatted text. Displays all whitespace chars.
-         container.innerHTML = `<div class="txtPreview"><pre>${fileContents}</pre></div>`;
-      } else {
-         container.innerHTML = `<div class="unsupportedPreview"><p>No preview available for this filetype.</p></div>`;
-      }
-   }     
+            // <pre> tag displays preformatted text. Displays all whitespace chars.
+            container.innerHTML = `<div class="txtPreview"><pre>${fileContents}</pre></div>`;
+        } else {
+            container.innerHTML = `<div class="unsupportedPreview"><p>No preview available for this filetype.</p></div>`;
+        }
+    }
 };

--- a/src/index.js
+++ b/src/index.js
@@ -49,10 +49,12 @@ ipcMain.handle("getFilesInDirectory", async () => {
    }
 });
 
-ipcMain.handle("delete-file", async (event, filePath) => {
+ipcMain.handle("delete-file", async (event, filePath) => { //filePath gets sent over from preload
    try {
-      await fs.promises.rm(filePath, { force: true });
-      return { success: true, message: "File deleted successfully" };
+      await fs.promises.rm(filePath, { force: true }); //fs.promises.rm(), this currently will remove 
+      // directories as well as files, do we want this? if not we can change it to fs.unlink(), which
+      //only does files
+      return { success: true, message: "File deleted successfully" }; //success is built in boolean feedback
    } catch (error) {
       console.error("Error deleting file:", error);
       return { success: false, message: error.message };

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-const { app, BrowserWindow, ipcMain, dialog } = require("electron");
+const { app, BrowserWindow, ipcMain, dialog, shell } = require("electron");
 const path = require("node:path");
 const fs = require("fs");
 
@@ -49,7 +49,15 @@ ipcMain.handle("getFilesInDirectory", async () => {
    }
 });
 
-
+ipcMain.handle("delete-file", async (event, filePath) => {
+   try {
+      await fs.promises.rm(filePath, { force: true });
+      return { success: true, message: "File deleted successfully" };
+   } catch (error) {
+      console.error("Error deleting file:", error);
+      return { success: false, message: error.message };
+   }
+});
 
 app.whenReady().then(createWindow);
 

--- a/src/preload.js
+++ b/src/preload.js
@@ -9,5 +9,6 @@ contextBridge.exposeInMainWorld('file', {
    setFilePath: (filePath) => ipcRenderer.send('setFilePath', filePath),
    getTimeStamp: () => new Date().toTimeString(),
    selectDirectory: async () => await ipcRenderer.invoke('selectDirectory'), // Always fetch latest value
-   getFilesInDirectory: () => ipcRenderer.invoke('getFilesInDirectory') // Fetch file list
+   getFilesInDirectory: () => ipcRenderer.invoke('getFilesInDirectory'), // Fetch file list
+   deleteFile: (filePath) => ipcRenderer.invoke('delete-file', filePath)
 });

--- a/src/preload.js
+++ b/src/preload.js
@@ -10,5 +10,5 @@ contextBridge.exposeInMainWorld('file', {
    getTimeStamp: () => new Date().toTimeString(),
    selectDirectory: async () => await ipcRenderer.invoke('selectDirectory'), // Always fetch latest value
    getFilesInDirectory: () => ipcRenderer.invoke('getFilesInDirectory'), // Fetch file list
-   deleteFile: (filePath) => ipcRenderer.invoke('delete-file', filePath)
+   deleteFile: (filePath) => ipcRenderer.invoke('delete-file', filePath) //delete file
 });

--- a/test/delete.test.js
+++ b/test/delete.test.js
@@ -1,0 +1,126 @@
+//components we need for testing
+const { expect } = require("chai");
+const fs = require("fs").promises;
+const path = require("path");
+const { EventEmitter } = require("events");
+const ipcMain = new EventEmitter();
+
+
+//group of deleting file test
+describe("IPC delete-file", function () {
+    const testDirectory = path.join(__dirname, "test-files"); //test directory
+    const testFiles = [ //array of common file types to ensure robust testing
+        path.join(testDirectory, "testFile.txt"), //test file txt
+        path.join(testDirectory, "testFile.pdf"), //test file pdf
+        path.join(testDirectory, "testFile.html"), //tests html 
+        path.join(testDirectory, "testFile.json"), //json
+        path.join(testDirectory, "testFile.mp3"), //mp3
+        path.join(testDirectory, "testFile.zip"), //zip
+        path.join(testDirectory, "testfile.jpeg") //jpeg
+    ];
+    before(async function () {
+        try {
+            await fs.mkdir(testDirectory, { recursive: true }); //make the test directory
+            console.log("Test directory created:", testDirectory);
+        } catch (error) {
+            console.error("Error creating test directory:", error);
+            throw error;
+        }
+    });
+    beforeEach(async function () {
+        try {
+            //these are populating our array of sample contents
+            await fs.writeFile(testFiles[0], "Text content", "utf8");
+            await fs.writeFile(testFiles[1], JSON.stringify({ key: "value" }), "utf8");
+            await fs.writeFile(testFiles[2], "<h1>Test</h1>", "utf8");
+            await fs.writeFile(testFiles[3], Buffer.from("%PDF-1.4\n...", "binary"));
+            await fs.writeFile(testFiles[4], Buffer.from([255, 216, 255, 224, 0, 16]), "binary");
+            await fs.writeFile(testFiles[5], Buffer.from([0x49, 0x44, 0x33]), "binary"); // MP3 header
+            await fs.writeFile(testFiles[6], Buffer.from([0x50, 0x4B, 0x03, 0x04]), "binary"); // ZIP header
+        } catch (error) {
+            console.error("Error creating test file:", error);
+            throw error;
+        }
+    });
+    //depopulating manually after each test
+    afterEach(async function () {
+        for (const filePath of testFiles) {
+            try {
+                await fs.unlink(filePath);
+            } catch (error) {
+                if (error.code !== "ENOENT") console.error("Error deleting test file:", error);
+            }
+        }
+    });
+    //remove the test directory after all tests so nothing left behind
+    after(async function () {
+        try {
+            await fs.rm(testDirectory, { recursive: true, force: true });
+        } catch (error) {
+            console.error("Error removing test directory:", error);
+            throw error;
+        }
+    });
+
+
+    //TEST DELETING COMMON FILE TYPES
+    it("will delete common file types", async function () {
+        //mocking event behavior, our deletion method
+        ipcMain.on("delete-file", async (event, filePath) => {
+            console.log(`Attempting to delete file: ${filePath}`);
+            try {
+                await fs.rm(filePath); //same logic that is in our actual code!
+                console.log(`File deleted successfully: ${filePath}`); // Debugging line
+            } catch (error) {
+                console.error("Error deleting file via IPC event:", error);
+            }
+        });
+
+        for (const filePath of testFiles) {
+            //be sure the file is accessable before trying to delete
+            try {
+                await fs.access(filePath);
+            } catch (error) {
+                throw new Error(`Test file ${filePath} does not exist before deletion.`);
+            }
+
+            // mock ipcMain delete method, event, and pass the file
+            ipcMain.emit("delete-file", {}, filePath);
+            // we have to include, give it time to execute or itll be weird
+            await new Promise((resolve) => setTimeout(resolve, 100));
+
+            //boolean to ensure file cannot be accessed (it got removed!)
+            let fileExists = true;
+            try {
+                await fs.access(filePath);
+            } catch (error) {
+                fileExists = false; //this should be hit!
+            }
+            expect(fileExists).to.be.false;
+        }
+    });
+    //TEST FOR DELETING A FILE THAT DOESNT EXIST
+    it("will error when trying to delete a fake file", async function () {
+        const fakeFile = path.join(testDirectory, "fakeFile.txt");
+        ipcMain.once("file-deletion-error", (event, errorMsg) => {
+            try {
+                expect(errorMsg).to.include("ENOENT"); //expect this error message
+                done(); //callback so no timeout
+            } catch (error) {
+                done(error);
+            }
+        });
+        //mocking event behavior, our deletion method, same as other test
+        ipcMain.on("delete-file", async (event, filePath) => {
+            console.log(`Attempting to delete file: ${filePath}`);
+            try {
+                await fs.promises.rm(filePath); //same logic that is in our actual code, NOW WILL ERROR (hopefully)
+                console.log(`File deleted successfully: ${filePath}`); // Debugging line
+            } catch (error) {
+                console.error("Error deleting file via IPC event:", error);
+            }
+        });
+        ipcMain.emit("delete-file", {}, fakeFile); //invoke mock IPC
+    });
+});
+


### PR DESCRIPTION
this PR handles file deletion for the directory that gets picked by the user on our page 2, this only handles HARD delete, meaning files get deleted, not sent to trash. 
When the user selects a directory, and selects go, it gets sent to the second page where now there is a delete button option, clicking this button DELETES the file from your machine. 
When a directory is in a directory, a popup is displayed saying this is a directory, does NOT delete 
<img width="1440" alt="Screenshot 2025-02-09 at 2 58 54 PM" src="https://github.com/user-attachments/assets/561b9ea7-6cc5-4d77-a636-e3def378966d" />
I have a couple tests for this PR as well, I test multiple common file types and ensure they get deleted, and attempting to delete a non existent file. 

Any further tests (busy files, permission denied, etc.) are OS dependent so I wasn't sure how to handle this.

to run the tests, run npx mocha test/delete.test.js, that test creates a pdf, html, zip, json, mp3, jpeg. Then mocks our IPCMain invocation of fs.promises.rm(file). It puts that logic, in the test file as it was the easiest way to do it I think. 

Fixes issue #19. 
