### PR TITLE
refactor: make Actions more selective

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,8 +25,11 @@ jobs:
       - name: Install dependencies
         run: npm ci # Ensures exact dependencies from package-lock.json
 
-      # Run Mocha tests before building
-      - name: Run Tests
+      # Run Mocha tests
+      - name: Run tests
         run: npm test
         env:
           NODE_ENV: test
+
+      - name: Build app
+        run: npm run

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     types: [ opened, reopened, edited ]
   push:
-    branches: [ main ]
+    branches: [ main, '*print*' ]
 
 jobs:
   # Run tests before building (only once on Windows)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,7 @@
 name: Test/build
 
 on:
-  workflow_call:
+  workflow_call: # Allows workflow to be invoked by other workflows
   pull_request:
     types: [ opened, reopened, edited ]
   push:
@@ -31,5 +31,6 @@ jobs:
         env:
           NODE_ENV: test
 
+      # Compile and run application
       - name: Build app
         run: npm run start

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,4 +33,4 @@ jobs:
 
       # Compile and run application
       - name: Build app
-        run: npm run start
+        run: npm run package

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,11 @@
-name: Build/release
+name: Test/build
 
-on: push
-
-# Necessary for automatic publishing of binaries.
-permissions:
-  contents: write
+on:
+  workflow_call:
+  pull_request:
+    types: [ opened, reopened, edited ]
+  push:
+    branches: [ main ]
 
 jobs:
   # Run tests before building (only once on Windows)
@@ -29,36 +30,3 @@ jobs:
         run: npm test
         env:
           NODE_ENV: test
-
-  release:
-    needs: test # Ensures this job runs only if 'test' passes
-    strategy:
-      matrix:
-        os: [macos-latest, ubuntu-latest, windows-latest] # Run build on three platforms
-
-    runs-on: ${{ matrix.os }}
-
-    steps:
-      - name: Check out Git repository
-        uses: actions/checkout@v1
-
-      - name: Install Node.js, NPM and Yarn
-        uses: actions/setup-node@v1
-        with:
-          node-version: 22.12
-
-      # Fixes temporary file conflicts.
-      - name: Clean cache
-        run: rm -rf ~/.cache/electron-builder
-        shell: bash # Resolves command portability.
-
-      - name: Build/release Electron app
-        uses: Yan-Jobs/action-electron-builder@v1.7.0
-        with:
-          # GitHub token, automatically provided to the action
-          # (No need to define this secret in the repo settings)
-          github_token: ${{ secrets.github_token }}
-
-          # If the commit is tagged with a version (e.g. "v1.0.0"),
-          # release the app after building
-          release: ${{ startsWith(github.ref, 'refs/tags/v') }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,4 +32,4 @@ jobs:
           NODE_ENV: test
 
       - name: Build app
-        run: npm run
+        run: npm run start

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,46 @@
+name: Deploy to drafted release
+
+on:
+  push:
+    tags:
+      - '*'
+
+# Necessary for automatic publishing of binaries.
+permissions:
+  contents: write
+
+jobs:
+  build:
+    uses: ./.github/workflows/build.yml
+  release:
+    needs: test # Ensures this job runs only if 'test' passes
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest] # Run build on three platforms
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v1
+
+      - name: Install Node.js, NPM and Yarn
+        uses: actions/setup-node@v1
+        with:
+          node-version: 22.12
+
+      # Fixes temporary file conflicts.
+      - name: Clean cache
+        run: rm -rf ~/.cache/electron-builder
+        shell: bash # Resolves command portability.
+
+      - name: Build/release Electron app
+        uses: Yan-Jobs/action-electron-builder@v1.7.0
+        with:
+          # GitHub token, automatically provided to the action
+          # (No need to define this secret in the repo settings)
+          github_token: ${{ secrets.github_token }}
+
+          # If the commit is tagged with a version (e.g. "v1.0.0"),
+          # release the app after building
+          release: ${{ startsWith(github.ref, 'refs/tags/v') }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,15 +3,17 @@ name: Deploy to drafted release
 on:
   push:
     tags:
-      - '*'
+      - '*' # Trigger workflow on new tags
 
 # Necessary for automatic publishing of binaries.
 permissions:
   contents: write
 
 jobs:
+  # Execute build/test workflow before deployment.
   build:
     uses: ./.github/workflows/build.yml
+
   deploy:
     strategy:
       matrix:
@@ -31,7 +33,8 @@ jobs:
       # Fixes temporary file conflicts.
       - name: Clean cache
         run: rm -rf ~/.cache/electron-builder
-        shell: bash # Resolves command portability.
+        # Resolves command portability.
+        shell: bash
 
       - name: Build/release Electron app
         uses: Yan-Jobs/action-electron-builder@v1.7.0

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,8 +12,7 @@ permissions:
 jobs:
   build:
     uses: ./.github/workflows/build.yml
-  release:
-    needs: test # Ensures this job runs only if 'test' passes
+  deploy:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest] # Run build on three platforms


### PR DESCRIPTION
This PR aims to make our GitHub Actions more time-efficient. We are allowed a limited number of monthly minutes when it comes to executing Actions workflows, so I have made their triggers more selective.

Currently, every time our GitHub repository detects a new push on __any branch__, our single workflow is triggered. Given that this workflow fully compiles binaries, this operation does not have to occur on every push.

I have split our single workflow into two:

+ `build.yml`: Runs unit tests and builds the application.
	+ Triggers on pushes to main and sprint branches, as well as pull requests.
+ `deploy.yml`: Deploys the project to a drafted release.
	+ Triggers only on a new Git tag.
	+ Runs `build.yml` prior to deployment.