### PR TITLE
changed alerts to showMessageBox 

### DIFF
--- a/src/breadNbutter/keep_or_delete.js
+++ b/src/breadNbutter/keep_or_delete.js
@@ -50,25 +50,40 @@ window.onload = async function () {
             // - bridge but actually exists at line 52 of index.js
 
             if (result.success) { //success is a built in boolean callback
-                alert("File deleted successfully!"); //THIS SHOULD GET REMOVED EVENTUALLY, IT IS JUST FOR DEBUGGING TO KNOW WHETHER IT WORKED OR NOT 
+                await window.file.showMessageBox({
+                    type: "info",
+                    title: "Success",
+                    message: "File deleted successfully"
+                }); //THIS SHOULD GET REMOVED EVENTUALLY, IT IS JUST FOR DEBUGGING TO KNOW WHETHER IT WORKED OR NOT 
             } else {
-                alert("Error: " + result.message);
-            }
+                await window.file.showMessageBox({
+                    type: "error",
+                    title: "Error",
+                    message: result.message
+                });            }
         } catch (error) {
             console.error("Error deleting file:", error);
-            alert("Error deleting file: " + error.message);
+            await window.file.showMessageBox({
+                type: "error",
+                title: "Error",
+                message: "Error deleting file: " + error.message
+            });
         }
     });
 
     // Go through files in directory +1
-    document.getElementById("nextButton").addEventListener("click", () => {
+    document.getElementById("nextButton").addEventListener("click", async () => {
         if (files.length > 0) {
             if (currentIndex < files.length - 1) {
                 currentIndex = (currentIndex + 1);
                 displayFile(files[currentIndex]);
             }
             else {
-                alert("No more files in selected Directory")
+                window.file.showMessageBox({
+                    type: "warning",
+                    title: "No Next File",
+                    message: "No more files in selected Directory"
+                });
             }
         }
     });
@@ -80,7 +95,11 @@ window.onload = async function () {
                 displayFile(files[currentIndex]);
             }
             else {
-                alert("No previous files selected Directory")
+                window.file.showMessageBox({
+                    type: "warning",
+                    title: "No Previous File",
+                    message: "No previous files in selected Directory"
+                });
             }
         }
 

--- a/src/index.js
+++ b/src/index.js
@@ -4,14 +4,18 @@ const fs = require("fs");
 const { promises: fsPromises } = require('fs');
 
 let selectedFilePath = ""; // Ensure this updates dynamically
+let mainWindow;
 
 const createWindow = () => {
-   const mainWindow = new BrowserWindow({
+   mainWindow = new BrowserWindow({
       width: 800,
       height: 600,
       webPreferences: {
          preload: path.join(__dirname, "preload.js"),
-         sandbox: false
+         sandbox: false,
+         nodeIntegration: false, 
+         contextIsolation: true,
+         enableRemoteModule: false,
       }
    });
 
@@ -82,4 +86,9 @@ app.whenReady().then(createWindow);
 
 app.on("window-all-closed", () => {
    if (process.platform !== "darwin") app.quit();
+});
+
+//handles message box to replace alerts
+ipcMain.handle('show-message-box', async (event, options) => {
+   return dialog.showMessageBox(mainWindow, options);
 });

--- a/src/preload.js
+++ b/src/preload.js
@@ -15,5 +15,6 @@ contextBridge.exposeInMainWorld('file', {
    pathJoin: (dir, file) => path.join(dir, file),
    pathDirname: (file) => path.dirname(file),
    pathBasename: (filePath) => path.basename(filePath),
-   deleteFile: (filePath) => ipcRenderer.invoke('delete-file', filePath) //delete file
+   deleteFile: (filePath) => ipcRenderer.invoke('delete-file', filePath), //delete file
+   showMessageBox: (options) => ipcRenderer.invoke('show-message-box', options), //message box to replace alerts
 });


### PR DESCRIPTION
There was a bug reported where alerts caused an issue accessing the renaming text box. This happened because of the way JS alerts work within Electron. Changed over to showMessageBox to solve this.

Made the showMessageBox accessible to renderer through ipc context bridge

Issue seems to be solved, any further alerts should use similar methodology, if there are any alerts I missed we should change those as well