### PR TITLE
Refactor/changed renaming logic for test support

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ const { app, BrowserWindow, ipcMain, dialog, shell } = require("electron");
 const path = require("node:path");
 const fs = require("fs");
 const { promises: fsPromises } = require('fs');
+const renameHandler = require("./renameHandler");
 
 let selectedFilePath = ""; // Ensure this updates dynamically
 let mainWindow;
@@ -27,6 +28,10 @@ ipcMain.handle('getFilePath', () => selectedFilePath);
 ipcMain.on('setFilePath', (event, filePath) => {
    selectedFilePath = filePath; // Ensure it updates
 });
+
+ipcMain.handle('rename', async (newName, directoryPath, windowFile, showNotification) => {
+   renameHandler.renameFileHandler(newName, directoryPath, windowFile, showNotification);
+})
 
 ipcMain.handle('selectDirectory', async () => {
    const result = await dialog.showOpenDialog({

--- a/src/index.js
+++ b/src/index.js
@@ -58,20 +58,22 @@ ipcMain.handle("getFilesInDirectory", async () => {
    }
 });
 
+//handle renameFile event triggered by renderer process
 ipcMain.handle('renameFile', async (event, { oldPath, newPath }) => {
-   console.log(`Renaming: ${oldPath} -> ${newPath}`);  // Debugging
-
+   console.log(`Renaming: ${oldPath} -> ${newPath}`);  //displays the file paths being renamed
+   //check for invalid path
    if (!oldPath || !newPath) {
-       console.error('Invalid paths:', { oldPath, newPath });
-       return { success: false, message: 'Invalid file paths provided.' };
+      console.error('Invalid paths:', { oldPath, newPath });
+      return { success: false, message: 'Invalid file paths provided.' };
    }
 
    try {
-       await fsPromises.rename(oldPath, newPath);  // Correctly use fs.promises.rename
-       return { success: true };
+      //rename the file using fs.promises.rename
+      await fsPromises.rename(oldPath, newPath); 
+      return { success: true };
    } catch (error) {
        console.error('Error renaming file:', error);
-       return { success: false, message: error.message };
+      return { success: false, message: error.message };
    }
 });
 

--- a/src/preload.js
+++ b/src/preload.js
@@ -2,11 +2,11 @@ const { contextBridge, ipcRenderer } = require('electron');
 const fs = require("node:fs");
 const mime = require("mime");
 const path = require('path');
+const { renameFileHandler, resetRenameInput } = require('./renameHandler.js');
 
 contextBridge.exposeInMainWorld('file', {
    getFilePath: () => ipcRenderer.invoke('getFilePath'),
    getFileContents: (path) => fs.readFileSync(path).toString(),
-   rename: (newName, directoryPath, windowFile, showNotification) => ipcRenderer.invoke('rename', newName, directoryPath, windowFile, showNotification),
    getMimeType: (path) => mime.getType(path),
    setFilePath: (filePath) => ipcRenderer.send('setFilePath', filePath),
    getTimeStamp: () => new Date().toTimeString(),
@@ -18,4 +18,10 @@ contextBridge.exposeInMainWorld('file', {
    pathBasename: (filePath) => path.basename(filePath),
    deleteFile: (filePath) => ipcRenderer.invoke('delete-file', filePath), //delete file
    showMessageBox: (options) => ipcRenderer.invoke('show-message-box', options), //message box to replace alerts
+});
+
+contextBridge.exposeInMainWorld('fileOperations', {
+   renameFileHandler: (newName, currentFilePath, windowFile, showNotification) => 
+       renameFileHandler(newName, currentFilePath, windowFile, showNotification),
+   resetRenameInput:(renameContainer) => resetRenameInput(renameContainer)
 });

--- a/src/preload.js
+++ b/src/preload.js
@@ -6,6 +6,7 @@ const path = require('path');
 contextBridge.exposeInMainWorld('file', {
    getFilePath: () => ipcRenderer.invoke('getFilePath'),
    getFileContents: (path) => fs.readFileSync(path).toString(),
+   rename: (newName, directoryPath, windowFile, showNotification) => ipcRenderer.invoke('rename', newName, directoryPath, windowFile, showNotification),
    getMimeType: (path) => mime.getType(path),
    setFilePath: (filePath) => ipcRenderer.send('setFilePath', filePath),
    getTimeStamp: () => new Date().toTimeString(),

--- a/src/renameHandler.js
+++ b/src/renameHandler.js
@@ -1,21 +1,50 @@
-async function renameFileHandler(newName, directoryPath, windowFile, showNotification) {
+async function renameFileHandler(newName, currentFilePath, windowFile, showNotification) {
     if (!newName) {
         showNotification('Please enter a new file name.', 'error');
         return 'error';
     }
 
-    const allFiles = await windowFile.getFilesInDirectory();
-    const finalName = newName.includes('.') ? newName : `${newName}.txt`;
+    const directoryPath = windowFile.pathDirname(currentFilePath);
+    //const allFiles = await windowFile.getFilesInDirectory();
+    const originalExtension = currentFilePath.substring(currentFilePath.lastIndexOf('.'));
+    const finalName = newName.includes('.') ? newName : `${newName}${originalExtension}`;
 
-    if (allFiles.includes(finalName)) {
+    const newFilePath = windowFile.pathJoin(directoryPath, finalName);
+
+    const allFilePaths = await windowFile.getFilesInDirectory();
+    const allFileNames = allFilePaths.map(filePath => windowFile.pathBasename(filePath));
+
+    //check for duplicate files and return 'error' if found
+    if (allFileNames.includes(finalName)) {
         showNotification(`A file named "${finalName}" already exists. Please choose a different name.`, 'error');
         return 'error';
     }
 
-    const newFilePath = windowFile.pathJoin(directoryPath, finalName);
-    await windowFile.renameFile('mockCurrentFile.txt', newFilePath);
-    showNotification(`File renamed successfully to ${finalName}`, 'success');
-    return 'success';
+    try {
+        console.log(`Renaming file from ${currentFilePath} to ${newFilePath}`); //log renaming attempt
+        await windowFile.renameFile(currentFilePath, newFilePath);
+        showNotification(`File renamed successfully to ${finalName}`, 'success');
+        return newFilePath; //return new file path for update
+    } catch (error) {
+        console.error(`Rename failed with error: ${error.message}`); //log error
+        showNotification(`Failed to rename file: ${error.message}`, 'error');
+        return 'error';
+    }
 }
 
-module.exports = { renameFileHandler };
+function resetRenameInput(container) {
+    container.innerHTML = '';  //clear the old input field
+
+    const newRenameInput = document.createElement('input');
+    newRenameInput.type = 'text';
+    newRenameInput.id = 'renameInput';
+    newRenameInput.placeholder = 'Enter new file name';
+
+    container.appendChild(newRenameInput);
+
+    setTimeout(() => {
+        newRenameInput.focus();  //focus input immediately
+    }, 100);
+}
+
+module.exports = { renameFileHandler, resetRenameInput };

--- a/test/renameTests.js
+++ b/test/renameTests.js
@@ -1,39 +1,34 @@
 const { expect } = require('chai');
-const { renameFileHandler } = require('../src/renameHandler');  // Adjust this path as needed
+const { renameFileHandler } = require('../src/renameHandler.js');
 
 describe('File Renaming Tests', () => {
     let mockFiles;
     let mockWindowFile;
     let notifications = [];
 
-    // Setup the mocks before each test
     beforeEach(() => {
-        // Mock list of files in the directory
         mockFiles = ['file1.txt', 'file2.txt', 'document.pdf'];
-
-        // Mock the notification system using an array to capture messages
         notifications = [];
 
         const mockShowNotification = (message, type) => {
             notifications.push({ message, type });
         };
 
-        // Mock window.file methods manually
         mockWindowFile = {
-            getFilesInDirectory: async () => mockFiles,  // Simulate getting files
-            renameFile: async (oldPath, newPath) => ({ success: true }),  // Simulate a successful rename
+            getFilesInDirectory: async () => mockFiles,
+            renameFile: async (oldPath, newPath) => ({ success: true }),
             pathBasename: (filePath) => require('path').basename(filePath),
             pathJoin: (dir, file) => require('path').join(dir, file),
+            pathDirname: (filePath) => require('path').dirname(filePath)  // FIX: Mock pathDirname
         };
 
-        // Make mockShowNotification available globally in the test
         global.mockShowNotification = mockShowNotification;
     });
 
     it('should rename the file when the name is unique', async () => {
-        const result = await renameFileHandler('file3.txt', '/mock/directory', mockWindowFile, mockShowNotification);
+        const result = await renameFileHandler('file3.txt', '/mock/directory/file1.txt', mockWindowFile, mockShowNotification);
 
-        expect(result).to.equal('success');
+        expect(result).to.not.equal('error');
         expect(notifications).to.deep.include({
             message: 'File renamed successfully to file3.txt',
             type: 'success'
@@ -41,7 +36,7 @@ describe('File Renaming Tests', () => {
     });
 
     it('should not rename the file if the name already exists', async () => {
-        const result = await renameFileHandler('file1.txt', '/mock/directory', mockWindowFile, mockShowNotification);
+        const result = await renameFileHandler('file1.txt', '/mock/directory/file2.txt', mockWindowFile, mockShowNotification);
 
         expect(result).to.equal('error');
         expect(notifications).to.deep.include({
@@ -51,7 +46,7 @@ describe('File Renaming Tests', () => {
     });
 
     it('should show an error if the input is empty', async () => {
-        const result = await renameFileHandler('', '/mock/directory', mockWindowFile, mockShowNotification);
+        const result = await renameFileHandler('', '/mock/directory/file2.txt', mockWindowFile, mockShowNotification);
 
         expect(result).to.equal('error');
         expect(notifications).to.deep.include({
@@ -60,5 +55,6 @@ describe('File Renaming Tests', () => {
         });
     });
 });
+
 
 

--- a/test/renameTests.js
+++ b/test/renameTests.js
@@ -1,12 +1,14 @@
 const { expect } = require('chai');
-const { renameFileHandler } = require('../src/renameHandler.js');
+const { renameFileHandler } = require('../src/renameHandler.js'); //import the function under renameHandler.js
 
 describe('File Renaming Tests', () => {
     let mockFiles;
     let mockWindowFile;
     let notifications = [];
 
+    //before each test, reset mocks and the notification
     beforeEach(() => {
+        //simulate the initial set of files in the directory
         mockFiles = ['file1.txt', 'file2.txt', 'document.pdf'];
         notifications = [];
 
@@ -19,12 +21,13 @@ describe('File Renaming Tests', () => {
             renameFile: async (oldPath, newPath) => ({ success: true }),
             pathBasename: (filePath) => require('path').basename(filePath),
             pathJoin: (dir, file) => require('path').join(dir, file),
-            pathDirname: (filePath) => require('path').dirname(filePath)  // FIX: Mock pathDirname
+            pathDirname: (filePath) => require('path').dirname(filePath)
         };
 
         global.mockShowNotification = mockShowNotification;
     });
 
+    //Test case: Rename the file when the new name is unique
     it('should rename the file when the name is unique', async () => {
         const result = await renameFileHandler('file3.txt', '/mock/directory/file1.txt', mockWindowFile, mockShowNotification);
 
@@ -35,6 +38,7 @@ describe('File Renaming Tests', () => {
         });
     });
 
+    //Test case: Should not rename if a file with the new name already exists
     it('should not rename the file if the name already exists', async () => {
         const result = await renameFileHandler('file1.txt', '/mock/directory/file2.txt', mockWindowFile, mockShowNotification);
 
@@ -45,6 +49,7 @@ describe('File Renaming Tests', () => {
         });
     });
 
+    //Test case: Shows an error if the input file name is empty 
     it('should show an error if the input is empty', async () => {
         const result = await renameFileHandler('', '/mock/directory/file2.txt', mockWindowFile, mockShowNotification);
 


### PR DESCRIPTION
The renaming logic has moved from the UI context in ```keep_or_delete.js```  to a standalone module ```renameHandler.js``` in order to support unit testing. The primary goal of this refactor is to make the renaming functionality testable. 

**Key Changes:**

- The ```renameFileHandler``` function accepts parameters like newName, directoryPath, and windowFile, making it independent of tightly coupled UI references.

- The original event listener ```renameButton``` remains in ```keep_or_delete.js``` but now delegates renaming tasks to the modular handler.

- Made the functions inside ```renameHandler.js``` accessible through the ```preload.js``` context bridge under the fileOperations namespace. 

**Testing:** 
Use ```npx mocha test/renameTests.js``` to perform testing for three test cases:

- Rename the file when the new name is unique
- Don't rename if a file with the new name already exists
- Display error if the input file name is empty 