### PR TITLE
Delete testing fix, and fix bug that exists in removing deleting files

### DIFF
--- a/src/breadNbutter/keep_or_delete.js
+++ b/src/breadNbutter/keep_or_delete.js
@@ -50,7 +50,18 @@ window.onload = async function () {
             // - bridge but actually exists at line 52 of index.js
 
             if (result.success) {
-                files = files.filter(file => file !== filePath); //dynamically filter files that gets rid of deleted
+                let newArr = [];
+                for (let file of files) {
+                    if (file !== filePath) {
+                        newArr.push(file);
+                    }
+                }
+                files = newArr; // Update files array
+
+                //files = files.filter(file => file !== filePath); //dynamically filter files that gets rid of deleted
+                //this creates a new array called that has the condition that it is not filePath
+
+
                 //success is a built in boolean callback
                 //await window.file.showMessageBox({
                 //    type: "info",

--- a/test/delete.test.js
+++ b/test/delete.test.js
@@ -9,39 +9,27 @@ let app;
 const filePath = path.resolve(__dirname, "../src/main_menu.html");
 const fileUrl = `file://${filePath}`;
 
-
 const testDirectory = path.join(__dirname, "test-files"); //test directory and files
 const testFiles = [ //array of common file types
-    path.join(testDirectory, "testFile.txt"),
-    path.join(testDirectory, "testFile.pdf"),
-    path.join(testDirectory, "testFile.html"),
-    path.join(testDirectory, "testFile.json"),
-    path.join(testDirectory, "testFile.mp3"),
-    path.join(testDirectory, "testFile.zip"),
-    path.join(testDirectory, "testFile.jpeg"),
+    path.join(testDirectory, "test.html"),
+    path.join(testDirectory, "test1.txt"),
 ];
-
 
 test.afterAll(async () => {
     await app.close();
-    try { //deleting test file dir and files
-        await fs.rm(testDirectory, { recursive: true, force: true });
-        console.log(`Deleted test directory: ${testDirectory}`);
+    try { //deleting test file dir and files REMOVED TO SHOW THAT THEY ARE NO LONGER
+        //await fs.rm(testDirectory, { recursive: true, force: true });
+        //console.log(`Deleted test directory: ${testDirectory}`);
     } catch (error) {
-        console.error(`Error deleting test directory: ${error}`);
+        //console.error(`Error deleting test directory: ${error}`);
     }
 });
 
 test.beforeEach(async () => {
     await fs.mkdir(testDirectory, { recursive: true });
     await Promise.all([ //populating test files with their data types
-        fs.writeFile(testFiles[0], "Text content", "utf8"),
-        fs.writeFile(testFiles[1], JSON.stringify({ key: "value" }), "utf8"),
-        fs.writeFile(testFiles[2], "<h1>Test</h1>", "utf8"),
-        fs.writeFile(testFiles[3], Buffer.from("%PDF-1.4\n...", "binary")),
-        fs.writeFile(testFiles[4], Buffer.from([255, 216, 255, 224, 0, 16]), "binary"),
-        fs.writeFile(testFiles[5], Buffer.from([0x49, 0x44, 0x33]), "binary"),
-        fs.writeFile(testFiles[6], Buffer.from([0x50, 0x4B, 0x03, 0x04]), "binary"),
+        fs.writeFile(testFiles[0], "<h1>Test</h1>", "utf8"),
+        fs.writeFile(testFiles[1], "Text content", "utf8"),
     ]);
     app = await electron.launch({
         args: ["./"],
@@ -49,29 +37,36 @@ test.beforeEach(async () => {
 });
 
 test("will delete common file types", async ({ page }) => {
-    await page.goto(fileUrl); //goto home page
-    await page.locator("#SelectButton").click();
-    await page.evaluate((testDirectory) => {
-        document.getElementById("filepath").innerText = testDirectory;
-    }, testDirectory); //select our test directory initialized at top of file
+    //this to line 56 is getting us to keep_or_delete.html
+    const window = await app.firstWindow();
+    await window.goto("file://" + path.resolve(__dirname, "../src/main_menu.html"));
+    // Intercept file selection dialog
+    await app.evaluate(({ dialog }, testDirectory) => {
+        dialog.showOpenDialog = async () => ({
+            canceled: false,
+            filePaths: [testDirectory], // Inject the test directory
+        });
+    }, testDirectory);
 
-    await page.locator("#goButton").click();
-    await page.waitForURL("**/keep_or_delete.html"); //goto keep_or_delete.html
-
+    // Click to open file picker, but our override will inject testDirectory
+    await window.locator("#SelectButton").click();
+    await window.locator("#goButton").click();
+    await window.waitForURL("**/keep_or_delete.html");
 
     for (let index in testFiles) {
         const fileExists = await fs.stat(testFiles[index]).then(() => true).catch(() => false);
         expect(fileExists).toBe(true); //iterate through array, stat sees if they exist
     }
+    //loop for going through files and deleting each
     for (let index of testFiles) {
-        await page.locator("#deleteButton").click(); //click delete
-        await page.waitForTimeout(500); //wait to ensure it completes
-        const fileExists = await fs.stat(testFiles[index]).then(() => true).catch(() => false);
+        await window.waitForTimeout(100);
+        await window.locator("#deleteButton").click(); //click delete
+        await window.waitForTimeout(100); //wait to ensure it completes
+        const fileExists = await fs.stat(testFiles[testFiles.indexOf(index)]).then(() => true).catch(() => false);
         expect(fileExists).toBe(false); //same thing as last test, but ensure it is FALSE now
-        await page.locator("#nextButton").click(); //next file
+        await window.locator("#nextButton").click(); //next file
+        //await window.waitForTimeout(100);
     }
-
-
 });
 
 


### PR DESCRIPTION
LOGIC: this pull request reworks the false positives we were getting on the deletion test functionality, and tweaked the deletion bug to solve it another way, as that was causing another bug causing us to skip some files during iteration. 
TESTING: to run my updated test run either npm test (runs all tests) or run npm test.delete.js (runs just my file)
MISC: the new deletion method now creates a NEW array, pushes every file that isn't the current one that got deleted, then update the global array of files to the new one thus removing the unwanted item. Maybe a more optimal solution down the line. 
Screenshots:
<img width="426" alt="Screenshot 2025-02-17 at 10 15 00 AM" src="https://github.com/user-attachments/assets/5574b45a-1f9b-413b-880d-c05e5dd2741d" />
Fixes #48 