### PR TITLE
Removing firefox and safari testing

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -38,18 +38,7 @@ export default defineConfig({
         {
             name: 'chromium',
             use: { ...devices['Desktop Chrome'] },
-        },
-
-        {
-            name: 'firefox',
-            use: { ...devices['Desktop Firefox'] },
-        },
-
-        {
-            name: 'webkit',
-            use: { ...devices['Desktop Safari'] },
-        },
-
+        }
         /* Test against mobile viewports. */
         // {
         //   name: 'Mobile Chrome',


### PR DESCRIPTION
## Why?
By default playwright tests safari, chromium, and firefox which is good for traditional web apps but when using electron we only need to test chromium. By removing these unnecessary tests we improve testing time substantially.

## What?
This was just a small config change, removing firefox and safari tests