### PR TITLE
fixed: PDF-AI CSP conflicts

### DIFF
--- a/src/breadNbutter/keep_or_delete.html
+++ b/src/breadNbutter/keep_or_delete.html
@@ -4,6 +4,12 @@
 <head>
    <meta charset="UTF-8" />
    <link rel="stylesheet" href="../stylesheet.css">
+   <meta http-equiv="Content-Security-Policy" content="default-src 'self';
+         script-src 'self';
+         connect-src 'self' https://610op4g6ei.execute-api.us-east-1.amazonaws.com;
+         object-src 'none'
+         " />
+   <meta http-equiv="X-Content-Security-Policy" content="default-src 'self'; script-src 'self'" />
    <title>KeepOrDelete</title>
 </head>
 <!-- Here u can add other tabs and compnents for display-->

--- a/src/index.js
+++ b/src/index.js
@@ -23,22 +23,6 @@ const createWindow = () => {
       }
    });
 
-   // Modify CORS headers for all responses
-     // Set CSP using session.defaultSession
-
-   session.defaultSession.webRequest.onHeadersReceived((details, callback) => {
-      callback({
-         responseHeaders: {
-            ...details.responseHeaders,
-            "Content-Security-Policy": [
-               "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; " +
-               //Allows us to make API calls to Lambda via https trigger
-               "connect-src 'self' https://610op4g6ei.execute-api.us-east-1.amazonaws.com; object-src 'none'; frame-src 'none';"
-            ],
-         },
-      });
-   });
-
    mainWindow.loadFile("src/main_menu.html");
 };
 


### PR DESCRIPTION
This PR fixes a conflict between Content-Security-Policy directives.

Currently, new CSP directive definitions are preventing `<iframe>` elements from rendering, particularly when displaying the contents of PDFs (and DOCXs, by extension).

I solved this by migrating the CSP definitions into the HTML file via a `<meta>` tag, then removing the manual definition of the `frame-src` directive. The combination of these two changes allows PDFs to be rendered correctly.