### PR TITLE
feat: isolated testing configuration

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -112,7 +112,7 @@ if (process.argv.includes("--test-config")) {
    configPath = path.join(configDir, "config.json")
 
    // Create the config file.
-   fs.writeFileSync(configPath, `{ "removedFileTypes": [] } `);
+   fs.writeFileSync(configPath, JSON.stringify([], null, 2));
 };
 
 //method to add a file type to the removeFileType

--- a/src/index.js
+++ b/src/index.js
@@ -1,14 +1,11 @@
-const { session } = require("electron");
-const { app, BrowserWindow, ipcMain, dialog, shell } = require("electron");
+const { app, BrowserWindow, ipcMain, dialog, remote } = require("electron");
 const path = require("node:path");
 const fs = require("fs");
 const { promises: fsPromises } = require('fs');
-const configPath = path.join(app.getPath('userData'), 'config.json');
-
+var configPath = path.join(app.getPath('userData'), 'config.json');
 
 let selectedFilePath = ""; // Ensure this updates dynamically
 let mainWindow;
-
 
 const createWindow = () => {
    mainWindow = new BrowserWindow({
@@ -99,7 +96,24 @@ const getConfig = () => {
    return config;
 };
 
+// Overrides config file for the duration of the process.
+// Intended for test cases.
+if (process.argv.includes("--test-config")) {
+   const tmp = require("tmp");
 
+   // Auto clean up config when the process exits.
+   tmp.setGracefulCleanup()
+
+   // Generate a randomized tmp directory.
+   // Clean it up even if it contains files.
+   configDir = tmp.dirSync({ unsafeCleanup: true }).name
+
+   // Overwrite global config path.
+   configPath = path.join(configDir, "config.json")
+
+   // Create the config file.
+   fs.writeFileSync(configPath, `{ "removedFileTypes": [] } `);
+};
 
 //method to add a file type to the removeFileType
 ipcMain.handle("removeFileType", async (event, fileType) => {

--- a/test/ai-rename.test.js
+++ b/test/ai-rename.test.js
@@ -14,7 +14,7 @@ const testFiles = [
 
 // Launch the Electron app
 test.beforeAll(async () => {
-  electronApp = await electron.launch({ args: ["./"] });
+  electronApp = await electron.launch({ args: ["./", "--test-config"] });
 
   // Create file contents
   await fs.mkdir(testDirectory, { recursive: true });

--- a/test/delete.test.js
+++ b/test/delete.test.js
@@ -25,7 +25,7 @@ test.beforeEach(async () => {
         fs.writeFile(testFiles[1], "Text content", "utf8"),
     ]);
     app = await electron.launch({
-        args: ["./"],
+        args: ["./", "--test-config"],
     });
 });
 

--- a/test/final.page.test.js
+++ b/test/final.page.test.js
@@ -13,7 +13,7 @@ const keptFiles = [
 ];
 
 test.beforeAll(async () => {
-    electronApp = await electron.launch({ args: ["./"] });
+    electronApp = await electron.launch({ args: ["./", "--test-config"] });
 
     await fs.mkdir(testDirectory, { recursive: true });
     await Promise.all(

--- a/test/main.menu.test.js
+++ b/test/main.menu.test.js
@@ -12,7 +12,7 @@ const testDirectory = path.join(__dirname, "test-files");
 
 //setting up app
 test.beforeAll(async () => {
-  app = await electron.launch({ args: ["./"] });
+  app = await electron.launch({ args: ["./", "--test-config"] });
   await fs.mkdir(testDirectory, { recursive: true });
 });
 

--- a/test/previews.test.js
+++ b/test/previews.test.js
@@ -22,7 +22,7 @@ class TestFile {
 
 // Create the empty test directory before running the tests.
 test.beforeAll(async () => {
-   electronApp = await electron.launch({ args: ["./"] });
+   electronApp = await electron.launch({ args: ["./", "--test-config"] });
 });
 
 test.afterAll(async () => {

--- a/test/rename.test.js
+++ b/test/rename.test.js
@@ -18,7 +18,7 @@ const testFiles = [
 
 // Launch the Electron app
 test.beforeAll(async () => {
-    electronApp = await electron.launch({ args: ["./"] });
+    electronApp = await electron.launch({ args: ["./", "--test-config"] });
 
     await fs.mkdir(testDirectory, { recursive: true });
     await Promise.all([

--- a/test/settings.test.js
+++ b/test/settings.test.js
@@ -9,7 +9,7 @@ const log = (message) => {
 
 // Launch the Electron app
 test.beforeAll(async () => {
-  electronApp = await electron.launch({ args: ["./"] });
+  electronApp = await electron.launch({ args: ["./", "--test-config"] });
 });
 
 test.afterAll(async () => {

--- a/test/settings.test.js
+++ b/test/settings.test.js
@@ -47,7 +47,7 @@ test('Settings page: toggle txt checkbox and check config update', async () => {
   // after leaving the page.
   const restoredState = await window.evaluate(() => document.getElementById('txt').checked);
   // Give the app time to process the configuration file.
-  expect(restoredState == newState, { timeout: 1_000 })
+  expect(restoredState == newState, { timeout: 2_000 })
 
   // Reset the checkbox to its original state (checked)
   log("Resetting 'txt' checkbox to checked...");

--- a/test/swipe.test.js
+++ b/test/swipe.test.js
@@ -17,7 +17,7 @@ const cleanTestDir = function() {
 }
 
 test.beforeAll(async () => {
-   electronApp = await electron.launch({ args: ["./"] });
+   electronApp = await electron.launch({ args: ["./", "--test-config"] });
 });
 
 test.beforeEach(async () => {


### PR DESCRIPTION
This PR introduces the `--test-config` argument that changes the default config path for the duration of the process. This means that the user settings are separate from test settings, and tests mutating the configuration do not interfere with other tests.

The configuration file is a randomly generated temporary file that is cleaned up when the process exits. Currently, this file's default settings are to include all files, aka exclude no file types.

Every test now calls this inside the `electron.launch` function call. This means that every time it is called (whether `beforeEach` or `beforeAll`), the configuration is reset to the default value.

## Notable changes

+ In `settings.test.js`, an assertion that the config file exists has been replaced by asserting that settings persist after leaving the settings page.
	+ New strategy is equivalent to the old strategy since the settings page is populated by reading the configuration file. The settings persist if and only if the config file exists.
	+ Changed due to GitHub Actions failing on this case, since the test no longer creates the user configuration file, which is what was being tested previously.