### PR TITLE
Rework Rename to create popup and embed AI 

### DIFF
--- a/src/main_page/keep_or_delete.html
+++ b/src/main_page/keep_or_delete.html
@@ -19,25 +19,27 @@
    <div id="dirDisplay">
       <p id="dirPath"></p>
       <button id="inspectButton">Inspect Document</button>
+      <button id="renameButton">Rename File</button>  
       <div id="previewContainer"></div>
    </div>
 
-   <div id="notification">
-   </div>
-
-   <div class="wrapper">
+   <div id="notification"> </div>
+   <dialog id="renameModal">
       <div id="renameContainer">
-        <input type="text" id="renameInput" placeholder="Enter new file name">
-        <p id="renameWarning"></p>
+         <input type="text" id="renameInput" placeholder="Enter new file name">
+         <p id="renameWarning"></p>
       </div>
-      <div class="popup" id="popup" placeholder="AI Suggested Name">
-        AI: <span id="popupContent"></span>
+      <div class="popup" id="popup">
+         AI: <span id="popupContent">Suggested Name</span>
       </div>
-    </div>
+      <div class="modal-buttons">
+         <button id="closeModal">Cancel</button>
+         <button id="confirmRename">Confirm</button>
+      </div>
+   </dialog>
     
-  <button id="renameButton">Rename File</button>  
-  <button id="aiButton">AI Suggestion</button>
-  <button id="backButton">Change Directory</button>
+  
+   <button id="backButton">Change Directory</button>
    <div class="file-info">
       <p id="currentItem"></p>
       <p id="currentItemSize"></p>
@@ -47,7 +49,7 @@
       <button id="nextButton">Keep</button>
       <button id="finalPageButton">Review & Finalize</button>
    </div>
-<div id="tooltip">Swipe left to delete, right to keep. You can also use arrow keys!</div>
+   <div id="tooltip">Swipe left to delete, right to keep. You can also use arrow keys!</div>
    <div>
       <a href="../trash_page.html" id="trash_button">
          <img src="trash.jpg" alt="Clickable Image" width="50">

--- a/src/main_page/keep_or_delete.html
+++ b/src/main_page/keep_or_delete.html
@@ -30,7 +30,7 @@
          <p id="renameWarning"></p>
       </div>
       <div class="popup" id="popup">
-         AI: <span id="popupContent">Suggested Name</span>
+          <span id="popupContent">AI Suggested Name</span>
       </div>
       <div class="modal-buttons">
          <button id="closeModal">Cancel</button>

--- a/src/main_page/keep_or_delete.js
+++ b/src/main_page/keep_or_delete.js
@@ -169,7 +169,22 @@ window.onload = async function () {
         }
     }
 
+    confirmRename
+    const renameModal = document.getElementById("renameModal");
+    const closeModal = document.getElementById("closeModal");
     document.getElementById('renameButton').addEventListener('click', async (event) => {
+        if (!hasFiles()) return;
+        renameModal.showModal();
+        event.preventDefault();
+        event.stopPropagation();
+        await handleRename();
+    });
+
+    closeModal.addEventListener("click", () => {
+        renameModal.close();
+    });
+
+    document.getElementById("confirmRename").addEventListener('click', async (event) => {
         if (!hasFiles()) return;
         event.preventDefault();
         event.stopPropagation();
@@ -231,6 +246,7 @@ window.onload = async function () {
             // Step 4: Perform the rename
             const response = await window.file.renameFile(currentFile, newFilePath);
             if (response.success) {
+                document.getElementById("renameModal").close();
                 showNotification(`File renamed successfully to ${finalName}`, 'success');
                 files[currentIndex] = newFilePath;
                 displayCurrentFile();
@@ -544,10 +560,12 @@ window.onload = async function () {
     });
 
 
-    document.getElementById("aiButton").addEventListener("click", () => {
+    document.getElementById('popup').addEventListener("click", () => {
         if (!hasFiles()) return;
         LLM();
     });
+
+
     function LLM() {
         popup.style.display = 'inline-block';
         const filename = files[currentIndex];

--- a/src/main_page/keep_or_delete.js
+++ b/src/main_page/keep_or_delete.js
@@ -169,19 +169,18 @@ window.onload = async function () {
         }
     }
 
-    confirmRename
     const renameModal = document.getElementById("renameModal");
     const closeModal = document.getElementById("closeModal");
     document.getElementById('renameButton').addEventListener('click', async (event) => {
         if (!hasFiles()) return;
         renameModal.showModal();
-        event.preventDefault();
-        event.stopPropagation();
-        await handleRename();
+        document.getElementById('popupContent').innerText = "AI Suggested Name"
     });
 
     closeModal.addEventListener("click", () => {
+        const renameContainer = document.getElementById('renameContainer');
         renameModal.close();
+        resetRenameInput(renameContainer);
     });
 
     document.getElementById("confirmRename").addEventListener('click', async (event) => {
@@ -559,7 +558,6 @@ window.onload = async function () {
         }
     });
 
-
     document.getElementById('popup').addEventListener("click", () => {
         if (!hasFiles()) return;
         LLM();
@@ -589,21 +587,31 @@ window.onload = async function () {
             ])
                 .then(response => {
                     const suggestion = response.choices[0].message;
-                    console.log("Renaming Suggestion:", suggestion.content);
-
+                    console.log("Renaming Suggestion:", suggestion.content);                                
                     // Display the popup and suggested name. 
-                    const popup = document.getElementById('popup');
                     const popupContent = document.getElementById('popupContent');
-                    popupContent.textContent = suggestion.content;
 
                     // Add a click event listener to the popup. Populates the input field wih the suggestion.
-                    popup.onclick = () => {
-                        const renameInput = document.getElementById('renameInput');
-                        if (renameInput && !renameInput.value.trim()) {
-                            renameInput.value = suggestion.content;
-                        }
-                        popup.style.display = 'none';
+                    const renameInput = document.getElementById('renameInput');
+                    if (renameInput) {
+                        renameInput.value = suggestion.content;
+                    
+                        // Remove previous animation classes
+                        renameInput.classList.remove("glowing", "wiggle");
+                    
+                        // Force reflow to restart animations
+                        void renameInput.offsetWidth;
+                    
+                        // Add animation classes again
+                        renameInput.classList.add("glowing", "wiggle");
+                    
+                        // Remove the classes after the animation completes
+                        setTimeout(() => { 
+                            renameInput.classList.remove("glowing", "wiggle"); 
+                        }, 500);
                     }
+                    document.getElementById('popupContent').textContent = "Get new AI Name";
+                                          
 
                 })
                 .catch(error => {
@@ -612,7 +620,6 @@ window.onload = async function () {
 
         }
     }
-
 
     // Checks to see if user is a test agent
     const isTesting = navigator.userAgent.includes("Playwright");

--- a/src/stylesheet.css
+++ b/src/stylesheet.css
@@ -362,3 +362,13 @@ code {
   padding: 10px; 
   box-shadow: 0 0 10px rgba(0,0,0,0.2); 
 }
+
+@keyframes inputGlow {
+  0% { box-shadow: 0 0 5px rgba(0, 255, 0, 0.5); }
+  50% { box-shadow: 0 0 15px rgba(0, 255, 0, 1); }
+  100% { box-shadow: 0 0 5px rgba(0, 255, 0, 0.5); }
+}
+
+.glowing {
+  animation: inputGlow 0.5s ease-out;
+}

--- a/src/stylesheet.css
+++ b/src/stylesheet.css
@@ -355,3 +355,10 @@ code {
   align-items: center;
   gap: 10px;
 }
+
+#renameModal {
+  border: 1px solid #ccc; 
+  border-radius: 10px;
+  padding: 10px; 
+  box-shadow: 0 0 10px rgba(0,0,0,0.2); 
+}


### PR DESCRIPTION
## Why 
The main app page has gotten clustered with all the different buttons and functionality. This change will help declutter the view and allow better functionality. 

fulfills one of the boxes for [#103](https://github.com/COSC481W-2025Winter/KeepOrDelete/issues/103) 
## Changes
- Added modal for rename 
- Removed rename input box from main page
- Moved AI buttons from main page to rename popup
- Changed AI to only use one button
- Auto populate Rename input with AI suggestion

## Screenshots
Removed extra buttons
![image](https://github.com/user-attachments/assets/c69e5260-8621-4ef0-9f01-1239f3fc7ef5)

Rename modal 
![image](https://github.com/user-attachments/assets/72301ce4-ebfe-4614-83be-5cd01c3a6dba)

