### PR TITLE
Progress Bar Display

### DIFF
--- a/src/main_page/keep_or_delete.html
+++ b/src/main_page/keep_or_delete.html
@@ -39,6 +39,11 @@
    </dialog>
     
    <p>Directory to be Sorted: <code><span id="filepath"></span></code></p>
+
+   <div id="progress-bar" class="glowing">
+      <div id="progress"></div>
+    </div>
+
    <button id="backButton">Change Directory</button>
 
    <div class="file-info">

--- a/src/main_page/keep_or_delete.html
+++ b/src/main_page/keep_or_delete.html
@@ -43,6 +43,7 @@
    <div id="progress-bar" class="glowing">
       <div id="progress"></div>
     </div>
+    <div id="dataSaved"></div> 
 
    <button id="backButton">Change Directory</button>
 

--- a/src/main_page/keep_or_delete.js
+++ b/src/main_page/keep_or_delete.js
@@ -506,16 +506,6 @@ window.onload = async function () {
         }
     }
 
-    //track Kept Files
-    function keepCurrentFile(index) {
-        if (files.length > 0) {
-            const currentFile = files[index];
-            if (!keptFiles.includes(currentFile)) {
-                keptFiles.push(currentFile);
-            }
-        }
-    }
-
     //button to go to the final page
     document.getElementById("finalPageButton").addEventListener("click", () => {
         localStorage.setItem("keptFiles", JSON.stringify(keptFiles));
@@ -556,17 +546,6 @@ window.onload = async function () {
         // Update button text
         document.getElementById("inspectButton").innerText = inspectMode ? "Exit Inspect" : "Inspect Document";
     });
-
-
-    //track Kept Files
-    function keepCurrentFile(index) {
-        if (files.length > 0) {
-            const currentFile = files[index];
-            if (!keptFiles.includes(currentFile)) {
-                keptFiles.push(currentFile);
-            }
-        }
-    }
 
     //button to go to the final page
     document.getElementById("finalPageButton").addEventListener("click", () => {

--- a/src/main_page/keep_or_delete.js
+++ b/src/main_page/keep_or_delete.js
@@ -20,8 +20,8 @@ window.onload = async function () {
         const completedFiles = keptFiles.length + filesToBeDeleted.length;
         const percent = totalFiles > 0 ? Math.round((completedFiles / totalFiles) * 100) : 0;
         progress.style.width = `${percent}%`;
-        progress.textContent = "%" + percent;
-        
+        progress.textContent = percent + "%";
+
         // Adding some glowing and scaling animation cause vibes.
         if (percent === 100) {
             progress.classList.add("complete");
@@ -186,7 +186,6 @@ window.onload = async function () {
     document.getElementById("nextButton").addEventListener("click", async () => {
         if (!hasFiles()) return;
         animateSwipe("right");
-        updateProgress();
     });
 
     // Next file function (aka Keep)

--- a/src/main_page/keep_or_delete.js
+++ b/src/main_page/keep_or_delete.js
@@ -379,6 +379,7 @@ window.onload = async function () {
         const previewHTML = await window.file.generatePreviewHTML(filePath);
         previewContainer.innerHTML = previewHTML || "<p>Preview not available</p>";
         resetPreviewPosition();
+        updateProgress();
     }
 
 

--- a/src/main_page/keep_or_delete.js
+++ b/src/main_page/keep_or_delete.js
@@ -12,6 +12,7 @@ class FileObject {
 
 let fileObjects = [];
 let currentIndex = 0;
+let spaceSaved = 0;
 
 window.onload = async function () {
     const previewContainer = document.getElementById("previewContainer");
@@ -29,9 +30,14 @@ window.onload = async function () {
         progress.style.width = `${percent}%`;
         progress.textContent = percent + "%";
 
+        // Calculate total space saved
+        const totalSpaceSaved = filesToBeDeleted.reduce((sum, file) => sum + file.size, 0);
+        
         // Adding some glowing and scaling animation cause vibes.
         if (percent === 100) {
             progress.classList.add("complete");
+            const saved = document.getElementById("dataSaved");
+            saved.textContent = "You've saved: " + formatFileSize(totalSpaceSaved) + "!";
             setTimeout(() => {
                 progress.classList.remove("complete");
             }, 1000);
@@ -40,7 +46,6 @@ window.onload = async function () {
         progress.classList.remove("glowing");
         void progress.offsetWidth;
         progress.classList.add("glowing");
-       
     }
     // Get stored file objects
     const storedObjects = JSON.parse(localStorage.getItem("fileObjects")) || [];

--- a/src/main_page/keep_or_delete.js
+++ b/src/main_page/keep_or_delete.js
@@ -12,6 +12,29 @@ window.onload = async function () {
     let keptFiles = JSON.parse(localStorage.getItem("keptFiles")) || [];
     let filesToBeDeleted = JSON.parse(localStorage.getItem("deletedFiles")) || [];
     const hasShownTooltip = sessionStorage.getItem("tooltipShown");
+    
+    // Progress Bar based on files left
+    const progress = document.getElementById("progress");
+    function updateProgress() {
+        const totalFiles = files.length + keptFiles.length + filesToBeDeleted.length;
+        const completedFiles = keptFiles.length + filesToBeDeleted.length;
+        const percent = totalFiles > 0 ? Math.round((completedFiles / totalFiles) * 100) : 0;
+        progress.style.width = `${percent}%`;
+        progress.textContent = "%" + percent;
+        
+        // Adding some glowing and scaling animation cause vibes.
+        if (percent === 100) {
+            progress.classList.add("complete");
+            setTimeout(() => {
+                progress.classList.remove("complete");
+            }, 1000);
+        }
+        // Re-trigger the glowing animation
+        progress.classList.remove("glowing");
+        void progress.offsetWidth;
+        progress.classList.add("glowing");
+       
+    }
     try {
         //this stretch of code checks if we are navigating to this page from the final page from
         //final page after finalize and select new directory, if yes, no directory shown, if no, get dir
@@ -146,6 +169,7 @@ window.onload = async function () {
                 currentIndex++;
             }*/
             displayCurrentFile();
+            updateProgress();
         }
         catch (error) {
             console.error("Error deleting file:", error);
@@ -162,6 +186,7 @@ window.onload = async function () {
     document.getElementById("nextButton").addEventListener("click", async () => {
         if (!hasFiles()) return;
         animateSwipe("right");
+        updateProgress();
     });
 
     // Next file function (aka Keep)
@@ -187,6 +212,7 @@ window.onload = async function () {
             /*currentIndex++;
             displayCurrentFile();
             keepCurrentFile(currentIndex - 1);*/
+            updateProgress();
         } catch {
             console.error("Error keeping file:", error);
             await window.file.showMessageBox({

--- a/src/main_page/keep_or_delete.js
+++ b/src/main_page/keep_or_delete.js
@@ -21,7 +21,9 @@ window.onload = async function () {
     // Progress Bar based on files left
     const progress = document.getElementById("progress");
     function updateProgress() {
-        const totalFiles = files.length + keptFiles.length + filesToBeDeleted.length;
+        const totalFiles = fileObjects.length;
+        const keptFiles = fileObjects.filter(f => f.status === "keep");
+        const filesToBeDeleted = fileObjects.filter(f => f.status === "delete");
         const completedFiles = keptFiles.length + filesToBeDeleted.length;
         const percent = totalFiles > 0 ? Math.round((completedFiles / totalFiles) * 100) : 0;
         progress.style.width = `${percent}%`;

--- a/src/stylesheet.css
+++ b/src/stylesheet.css
@@ -417,3 +417,29 @@ code {
   animation: inputGlow 0.5s ease-out;
 }
 
+#progress-bar {
+  display: flex;
+  align-items: center;
+  width: 500px;
+  height: 20px;
+  background-color: #ddd;
+  margin: 0 auto;
+  animation: inputGlow 0.5s ease-out;
+}
+
+#progress {
+  width: 0%;
+  height: 100%;
+  background-color: #08c27bfc;
+  transition: width 0.5s ease-out;
+}
+
+@keyframes celebrate {
+  0%   { transform: scale(1); }
+  50%  { transform: scale(1.1); }
+  100% { transform: scale(1); }
+}
+
+.complete {
+  animation: celebrate 1s ease-out;
+}


### PR DESCRIPTION
Resolves #93  partially 

## Progress Bar Display

This pull request adds a progress bar that fills up as you swipe through the current directory.

## Changes

- Added function call for correct indexing while moving through directory.
- Added CSS styling to make progress bar come to life.
- Added text to show user how much space they have saved.

## Why?
- A progress bar visually represents how far the user has progressed through the directory.
- By displaying progression, the experience feels more interactive.

## Example
<img width="1470" alt="Screenshot 2025-03-29 at 4 14 20 PM" src="https://github.com/user-attachments/assets/21f098dc-2fc4-42ec-8f87-d233d9cbd873" />

<img width="1470" alt="Screenshot 2025-03-29 at 5 01 07 PM" src="https://github.com/user-attachments/assets/b517fe49-fa3c-4155-b358-2c9d63ae8515" />
