### PR TITLE
Logging image requests for AI renaming suggestions 

### DIFF
--- a/src/final_page.js
+++ b/src/final_page.js
@@ -4,6 +4,12 @@ window.onload = async function () {
     const deletedFilesList = document.getElementById("deletedFilesList");
     const fileObjects = JSON.parse(localStorage.getItem("fileObjects")) || [];
 
+    // Get references to the image limit and logged time to preserve after refresh
+    const Limitkey = "imageLimit";
+    const Timekey = "loggedTime";
+    const preservedLimit = parseInt(localStorage.getItem("imageLimit") || "0", 10);
+    const preservedTime = parseInt(localStorage.getItem("loggedTime") || "0", 10);
+
     // Render the file lists based on the stored file objects
     function renderFileLists() {
         keptFilesList.innerHTML = "";
@@ -192,6 +198,8 @@ window.onload = async function () {
         }
         localStorage.clear(); // Clears stored session data
         localStorage.setItem("finalPage", 'true');
+        localStorage.setItem(Limitkey, preservedLimit);
+        localStorage.setItem(Timekey, preservedTime);
         window.location.href = "./main_page/keep_or_delete.html";
     });
 
@@ -212,6 +220,8 @@ window.onload = async function () {
         }
         window.file.quitApp(); // Calls the function to quit the app
         localStorage.clear(); // Clears stored session data
+        localStorage.setItem(Limitkey, preservedLimit);
+        localStorage.setItem(Timekey, preservedTime);
     });
     renderFileLists();
 };

--- a/src/main_page/keep_or_delete.js
+++ b/src/main_page/keep_or_delete.js
@@ -19,7 +19,6 @@ let currentX;
 let isSwiping;
 let startTime; 
 let spaceSaved = 0;
-let ImageLimit = 0;
 
 window.onload = async function () {
     // Cache DOM references
@@ -693,14 +692,29 @@ window.onload = async function () {
         // Jpeg or png
         else if (mimeType.startsWith("image/")) {
             const currentTime = Date.now();
-            // if over limit of 2 images per day
-            if (ImageLimit > 1 && currentTime - localStorage.getItem("loggedTime") < 86400000) {
-                popupContentElement.textContent = "You have reached the image limit for the day.";
-                setTimeout(() => {
-                  popupContentElement.textContent = "Try another file buddy 😭"; 
-                }, 3000);
-                return;
+            // Get the image limit and logged time from local storage
+            let imageLimit = parseInt(localStorage.getItem("imageLimit") || "0", 10);
+            let loggedTime = parseInt(localStorage.getItem("loggedTime") || "0", 10);
+            
+            // 60000 minute
+            // 86400000 24 hours
+            // If 24 hours haven't passed and the image limit is reached, they cooked 
+            if ((currentTime - loggedTime) <= 86400000 && imageLimit >= 1) {
+              popupContentElement.textContent = "You have reached the limit for the day.";
+              setTimeout(() => {
+                popupContentElement.textContent = "Try another file thats not an image fam 😭"; 
+              }, 3000);
+              return;
             }
+            
+            //reset the counter if 24 hours have passed
+            if (currentTime - loggedTime > 86400000) {
+              imageLimit = 0;
+              loggedTime = currentTime;
+              localStorage.setItem("imageLimit", imageLimit);
+              localStorage.setItem("loggedTime", loggedTime);
+            }
+            
           try {
             const base64Image = window.file.getBase64(filename);
             popupContentElement.textContent = "Thinking...";
@@ -732,10 +746,10 @@ window.onload = async function () {
               .then((response) => {
                 const suggestion = response.choices[0].message;
                 console.log("Renaming Suggestion:", suggestion.content);  
-                // Update the logged time and image limit
-                const loggedTimeMillis = Date.now();  
-                localStorage.setItem("LoggedTime", loggedTimeMillis); 
-                ImageLimit++;                          
+                // Update the logged time and image limit in localStorage
+                localStorage.setItem("loggedTime", currentTime);
+                imageLimit++;
+                localStorage.setItem("imageLimit", imageLimit);                       
                 // Add a click event listener to the popup. Populates the input field wih the suggestion.
                 if (renameInputElement) {
                     renameInputElement.value = suggestion.content;

--- a/src/main_page/keep_or_delete.js
+++ b/src/main_page/keep_or_delete.js
@@ -697,7 +697,7 @@ window.onload = async function () {
             let loggedTime = parseInt(localStorage.getItem("loggedTime") || "0", 10);
 
              //reset the counter if 24 hours have passed
-             if (currentTime - loggedTime > 120000) {
+             if (currentTime - loggedTime > 86400000) {
                 imageLimit = 0;
                 loggedTime = currentTime;
                 localStorage.setItem("imageLimit", imageLimit);
@@ -707,7 +707,7 @@ window.onload = async function () {
             // 60000 minute
             // 86400000 24 hours
             // If 24 hours haven't passed and the image limit is reached, they cooked 
-            if ((currentTime - loggedTime) <= 120000 && imageLimit >= 2) {
+            if ((currentTime - loggedTime) <= 86400000 && imageLimit >= 2) {
               popupContentElement.textContent = "You have reached the limit for the day.";
               setTimeout(() => {
                 popupContentElement.textContent = "Try another file thats not an image fam 😭"; 

--- a/src/main_page/keep_or_delete.js
+++ b/src/main_page/keep_or_delete.js
@@ -695,26 +695,25 @@ window.onload = async function () {
             // Get the image limit and logged time from local storage
             let imageLimit = parseInt(localStorage.getItem("imageLimit") || "0", 10);
             let loggedTime = parseInt(localStorage.getItem("loggedTime") || "0", 10);
-            
+
+             //reset the counter if 24 hours have passed
+             if (currentTime - loggedTime > 120000) {
+                imageLimit = 0;
+                loggedTime = currentTime;
+                localStorage.setItem("imageLimit", imageLimit);
+                localStorage.setItem("loggedTime", loggedTime);
+              }
+
             // 60000 minute
             // 86400000 24 hours
             // If 24 hours haven't passed and the image limit is reached, they cooked 
-            if ((currentTime - loggedTime) <= 86400000 && imageLimit >= 1) {
+            if ((currentTime - loggedTime) <= 120000 && imageLimit >= 2) {
               popupContentElement.textContent = "You have reached the limit for the day.";
               setTimeout(() => {
                 popupContentElement.textContent = "Try another file thats not an image fam 😭"; 
-              }, 3000);
+              }, 4000);
               return;
             }
-            
-            //reset the counter if 24 hours have passed
-            if (currentTime - loggedTime > 86400000) {
-              imageLimit = 0;
-              loggedTime = currentTime;
-              localStorage.setItem("imageLimit", imageLimit);
-              localStorage.setItem("loggedTime", loggedTime);
-            }
-            
           try {
             const base64Image = window.file.getBase64(filename);
             popupContentElement.textContent = "Thinking...";
@@ -746,8 +745,6 @@ window.onload = async function () {
               .then((response) => {
                 const suggestion = response.choices[0].message;
                 console.log("Renaming Suggestion:", suggestion.content);  
-                // Update the logged time and image limit in localStorage
-                localStorage.setItem("loggedTime", currentTime);
                 imageLimit++;
                 localStorage.setItem("imageLimit", imageLimit);                       
                 // Add a click event listener to the popup. Populates the input field wih the suggestion.

--- a/src/main_page/keep_or_delete.js
+++ b/src/main_page/keep_or_delete.js
@@ -19,6 +19,7 @@ let currentX;
 let isSwiping;
 let startTime; 
 let spaceSaved = 0;
+let ImageLimit = 0;
 
 window.onload = async function () {
     // Cache DOM references
@@ -691,6 +692,15 @@ window.onload = async function () {
         }
         // Jpeg or png
         else if (mimeType.startsWith("image/")) {
+            const currentTime = Date.now();
+            // if over limit of 2 images per day
+            if (ImageLimit > 1 && currentTime - localStorage.getItem("loggedTime") < 86400000) {
+                popupContentElement.textContent = "You have reached the image limit for the day.";
+                setTimeout(() => {
+                  popupContentElement.textContent = "Try another file buddy 😭"; 
+                }, 3000);
+                return;
+            }
           try {
             const base64Image = window.file.getBase64(filename);
             popupContentElement.textContent = "Thinking...";
@@ -721,8 +731,11 @@ window.onload = async function () {
               ])
               .then((response) => {
                 const suggestion = response.choices[0].message;
-                console.log("Renaming Suggestion:", suggestion.content);                               
-
+                console.log("Renaming Suggestion:", suggestion.content);  
+                // Update the logged time and image limit
+                const loggedTimeMillis = Date.now();  
+                localStorage.setItem("LoggedTime", loggedTimeMillis); 
+                ImageLimit++;                          
                 // Add a click event listener to the popup. Populates the input field wih the suggestion.
                 if (renameInputElement) {
                     renameInputElement.value = suggestion.content;

--- a/test/ai-rename.test.js
+++ b/test/ai-rename.test.js
@@ -10,17 +10,35 @@ let electronApp;
 const testFiles = [
   path.join(testDirectory, "testFile.txt"),
   path.join(testDirectory, "testFile2.txt"),
+  path.join(testDirectory, "testFile3.png"),
+  path.join(testDirectory, "testFile4.png"),
+  path.join(testDirectory, "testFile5.png"),
 ];
 
 // Launch the Electron app
 test.beforeAll(async () => {
-  electronApp = await electron.launch({ args: ["./", "--test-config"], userAgent: "Playwright"  });
+  electronApp = await electron.launch({
+    args: ["./", "--test-config"],
+    userAgent: "Playwright",
+  });
+
+
+// Dummy image Base64 data (for a simple 20x20 PNG)
+const imgData = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAA"
++ "ABQAAAAUCAYAAACNiR0NAAAAKElEQVQ4jWNgYGD4Twzu6FhFFGYYNXDUwGFpI"
++ "Ak2E4dHDRw1cDgaCAASFOffhEIO3gAAAABJRU5ErkJggg==";
+// Remove the header and convert to a Buffer
+const data = imgData.replace(/^data:image\/\w+;base64,/, "");
+const dummyImageBuffer = Buffer.from(data, "base64");
 
   // Create file contents
   await fs.mkdir(testDirectory, { recursive: true });
   await Promise.all([
     fs.writeFile(testFiles[0], "Name this file 'hi'", "utf8"),
     fs.writeFile(testFiles[1], "", "utf8"),
+    fs.writeFile(testFiles[2], dummyImageBuffer),
+    fs.writeFile(testFiles[3], dummyImageBuffer),
+    fs.writeFile(testFiles[4], dummyImageBuffer),
   ]);
 });
 
@@ -36,6 +54,7 @@ test.afterAll(async () => {
   }
 });
 
+// Test 1
 test("Clicking on AI button returns expected message", async ({ page }) => {
   const window = await electronApp.firstWindow();
   await window.evaluate(() => localStorage.clear());
@@ -60,8 +79,6 @@ test("Clicking on AI button returns expected message", async ({ page }) => {
 
   // Navigate to keep or delete page with mock directory
   await window.click("#selectDirButton");
-  //await window.click("#goButton");
-  //await expect(window.url()).toContain("keep_or_delete.html");
 
   // Make sure selected file has contents. This would be passed on to AWS Lambda
   await window.locator("#renameButton").click();
@@ -78,6 +95,71 @@ test("Clicking on AI button returns expected message", async ({ page }) => {
   await window.locator("#popupContent").click();
   const popupContentLocator = window.locator("#popupContent");
   await expect(popupContentLocator).toContainText("No file contents found.");
+  await window.locator("#closeModal").click();
 
+  await window.evaluate(() => localStorage.clear());
+});
+
+
+// Test 2
+test("Image renaming limit prevents additional processing", async () => {
+  const window = await electronApp.firstWindow();
+
+  // Clear any previous data
+  await window.evaluate(() => localStorage.clear());
+
+  // Mock the GPT response for image renaming
+  const context = electronApp.context();
+  await context.route("**/GPT_Renaming", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        choices: [{ message: { content: "dummy image suggestion" } }],
+      }),
+    });
+  });
+
+  // Override the directory selection so it always returns our test directory
+  await electronApp.evaluate(({ dialog }, testDirectory) => {
+    dialog.showOpenDialog = async () => ({
+      canceled: false,
+      filePaths: [testDirectory],
+    });
+  }, testDirectory);
+
+  // Simulate navigating to the main page by clicking the select directory button.
+  await window.locator("#backButton").click();
+  // move past text files.  
+  await window.locator("#nextButton").click();
+  await window.waitForTimeout(1000);
+  await window.locator("#nextButton").click();
+  await window.waitForTimeout(1000);
+
+  // Process the first image
+  await window.click("#renameButton");
+  await window.click("#popupContent");
+  await window.locator("#closeModal").click();
+  await window.locator("#nextButton").click();
+
+  // Process the second image
+  await window.click("#renameButton");
+  await window.click("#popupContent");
+  await window.locator("#closeModal").click();
+  await window.locator("#nextButton").click();
+
+  // Process the third image, which should be blocked by the limit logic
+  await window.click("#renameButton");
+  await window.click("#popupContent");
+  const popupContentText = await window.locator("#popupContent").innerText();
+  await expect(popupContentText).toContain("reached the limit");
+
+  // Verify that the imageLimit remains at "2" in localStorage.
+  const imageLimitStored = await window.evaluate(() =>
+    localStorage.getItem("imageLimit")
+  );
+  await expect(imageLimitStored).toBe("2");
+
+  // Clean up localStorage after test.
   await window.evaluate(() => localStorage.clear());
 });


### PR DESCRIPTION
Resolves #114 

## AI Enhancements 

This pull request introduces restrictions on the number of rename suggestion requests that users can submit for images.

## Changes
- Added logs to local storage 
- Minor changes to final page to make sure log is never cleared. 
- Added tests for logging

## Why?
- Adding restrictions reduces the amount of tokens being burned for image processing

## Example
<img width="1470" alt="Screenshot 2025-04-01 at 12 12 19 PM" src="https://github.com/user-attachments/assets/bd70c645-db7e-4b24-b174-897e8528dcff" />
<img width="1470" alt="Screenshot 2025-04-01 at 12 13 01 PM" src="https://github.com/user-attachments/assets/2c4f38e1-5385-4cbd-861b-ed258dc6b198" />
<img width="741" alt="Screenshot 2025-04-01 at 12 10 44 PM" src="https://github.com/user-attachments/assets/5b5f5ad0-8fae-474d-a44c-86260f1fef2a" />
