### PR TITLE
Added alphabetical sorting for files

### DIFF
--- a/src/main_page/keep_or_delete.html
+++ b/src/main_page/keep_or_delete.html
@@ -24,7 +24,14 @@
    <div id="dirDisplay">
       <p id="dirPath"></p>
       <button id="inspectButton">Inspect Document</button>
-      <button id="renameButton">Rename File</button>  
+      <button id="renameButton">Rename File</button>
+      <div class="sort-container">
+         <label for="sortOrder" class="sort-label">Sort Order:</label>
+         <select id="sortOrder" class="sort-dropdown">
+            <option value="asc">A → Z</option>
+            <option value="desc">Z → A</option>
+         </select>
+      </div>      
       <div id="previewContainer"></div>
    </div>
 

--- a/src/main_page/keep_or_delete.js
+++ b/src/main_page/keep_or_delete.js
@@ -46,6 +46,8 @@ window.onload = async function () {
     let inspectMode = false;
     const hasShownTooltip = sessionStorage.getItem("tooltipShown");
     const dirPath = await window.file.getFilePath();
+    const sortOrderDropdown = document.getElementById("sortOrder");
+
     if (!dirPath) {
         // Hide all UI elements except welcomeScreen
         hideUIElements();
@@ -183,6 +185,25 @@ window.onload = async function () {
         }
     }
     
+    sortOrderDropdown.addEventListener("change", () => {
+        sortFiles();
+        currentIndex = 0;
+        displayCurrentFile();
+        sortOrderDropdown.blur()
+    });
+    
+
+    function sortFiles() {
+        const sortOrder = sortOrderDropdown.value;
+        fileObjects.sort((a, b) => {
+            const nameA = a.name.toLowerCase();
+            const nameB = b.name.toLowerCase();
+            if (nameA < nameB) return sortOrder === "asc" ? -1 : 1;
+            if (nameA > nameB) return sortOrder === "asc" ? 1 : -1;
+            return 0; // Stable sort
+        });
+        localStorage.setItem("fileObjects", JSON.stringify(fileObjects));
+    }
 
     function showNotification(message) {
         const notification = notificationElement;

--- a/src/stylesheet.css
+++ b/src/stylesheet.css
@@ -470,3 +470,27 @@ body.keep-or-delete.show {
   opacity: 1;
 }
 
+.sort-container {
+  display: flex;
+  justify-content: center;
+  margin: 10px 50px 5px 0;
+  align-items: center;
+}
+
+.sort-label {
+  margin-right: 10px;
+  font-weight: bold;
+}
+
+.sort-dropdown {
+  padding: 6px 10px;
+  font-size: 1rem;
+  border-radius: 5px;
+  border: 1px solid #ccc;
+  background-color: white;
+  cursor: pointer;
+}
+
+.sort-dropdown:hover {
+  border-color: #007bff;
+}

--- a/test/previews.test.js
+++ b/test/previews.test.js
@@ -85,6 +85,7 @@ test("Preview `.txt`", async () => {
    const f = new TestFile("test.txt", "Standard text file", "utf8");
    await setupWithTestFile(f);
 
+   await window.waitForSelector("#previewContainer pre, #previewContainer p", { timeout: 2000 });
    const preview = await window.locator("#previewContainer").innerText();
 
    expect(preview).toEqual(f.contents);
@@ -96,6 +97,7 @@ test("Preview `.csv`", async () => {
    const f = new TestFile("test.csv", "Standard csv file", "utf8");
    await setupWithTestFile(f);
 
+   await window.waitForSelector("#previewContainer pre, #previewContainer p", { timeout: 2000 });
    const preview = await window.locator("#previewContainer").innerText();
 
    expect(preview).toEqual(f.contents);
@@ -236,6 +238,7 @@ test("Preview `.frog` (unsupported)", async () => {
    const f = new TestFile("tree.frog", "Frog file contents ribbit", "utf8");
    await setupWithTestFile(f);
 
+   await window.waitForSelector("#previewContainer pre, #previewContainer p", { timeout: 2000 });
    const preview = await window.locator("#previewContainer").innerText();
 
    expect(preview).toMatch(noPreviewMsg);

--- a/test/sorting.test.js
+++ b/test/sorting.test.js
@@ -1,0 +1,75 @@
+const { test, expect, _electron: electron } = require('@playwright/test');
+const path = require('path');
+const fs = require('fs/promises');
+
+let electronApp;
+const testDirectory = path.join(__dirname, 'test-files');
+
+// Test files
+const testFiles = [
+    path.join(testDirectory, 'A.txt'),
+    path.join(testDirectory, 'b.txt'),
+    path.join(testDirectory, 'c.txt'),
+];
+
+test.beforeAll(async () => {
+    electronApp = await electron.launch({ args: ['./', '--test-config'], userAgent: 'Playwright' });
+
+    await fs.mkdir(testDirectory, { recursive: true });
+    await Promise.all(testFiles.map(file => fs.writeFile(file, 'Sample', 'utf8')));
+
+    // Ensure LocalStorage is cleared before each test
+    const window = await electronApp.firstWindow();
+    await window.evaluate(() => localStorage.clear());  
+});
+
+test.afterAll(async () => {
+    await electronApp.close();
+    try {
+        await fs.rm(testDirectory, { recursive: true, force: true });
+    } catch (error) {
+        console.error(`Error deleting test directory: ${error}`);
+    }
+});
+
+test('Sort dropdown sorts files alphabetically A→Z and Z→A', async () => {
+    const window = await electronApp.firstWindow();
+    await window.evaluate(() => localStorage.clear());
+    await window.goto("file://" + path.resolve(__dirname, "../src/main_page/keep_or_delete.html"));
+
+    // Mock file selection dialog
+    await electronApp.evaluate(({ dialog }, testDirectory) => {
+        dialog.showOpenDialog = async () => ({
+            canceled: false,
+            filePaths: [testDirectory],
+        });
+    }, testDirectory);
+
+    // Click to select directory and go to KeepOrDelete page
+    await window.locator('#selectDirButton').click();
+
+    const getCurrentFileName = async () => {
+        const text = await window.locator('#currentItem').innerText();
+        return text.replace('Current File: ', '').trim();
+    };
+
+    // Default should be A→Z
+    let fileName = await getCurrentFileName();
+    expect(fileName.toLowerCase()).toBe('a.txt');
+
+    // Change to Z→A
+    await window.locator('#sortOrder').selectOption('desc');
+    await window.waitForTimeout(500); // allow re-sort/render
+
+    fileName = await getCurrentFileName();
+    expect(fileName.toLowerCase()).toBe('c.txt');
+
+    // Change back to A→Z
+    await window.locator('#sortOrder').selectOption('asc');
+    await window.waitForTimeout(500);
+
+    fileName = await getCurrentFileName();
+    expect(fileName.toLowerCase()).toBe('a.txt');
+
+    await window.evaluate(() => localStorage.clear());
+});


### PR DESCRIPTION
Resolves #92 
This PR implements the ability to sort files alphabetically (A→Z or Z→A) on the KeepOrDelete screen.

## Updates and features

- Added a sorting dropdown above the preview container to control file display order.
- Sorting is case-insensitive and stable (e.g., A.txt = a.txt).
- Default sort is A→Z on load.
- Dropdown removes focus after selection to prevent arrow key conflicts.

## Testing
Added testing for:
- Verifying file sort order (A→Z and Z→A).
- Verified dropdown updates the preview file immediately.

## Screenshots
![image](https://github.com/user-attachments/assets/c9ec6d63-c3dc-47db-8045-045fd4e0c568)