### PR TITLE
Progress bar hotfix and llm polishing

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -33,10 +33,12 @@ const createWindow = () => {
  /* pdf2json library converts a PDF into a JSON structure, 
  This custom function is created to process the JSON structure 
  and extract all text into one continuous string.*/
-function extractPDFText(pdfData) {
+ function extractPDFText(pdfData) {
    let fullText = "";
    if (pdfData && Array.isArray(pdfData.Pages)) {
-     pdfData.Pages.forEach((page) => {
+     // Only process the first two pages
+     const pagesToProcess = pdfData.Pages.slice(0, 2);
+     pagesToProcess.forEach((page) => {
        if (Array.isArray(page.Texts)) {
          page.Texts.forEach((textItem) => {
            if (Array.isArray(textItem.R)) {

--- a/src/main_page/keep_or_delete.js
+++ b/src/main_page/keep_or_delete.js
@@ -632,7 +632,6 @@ window.onload = async function () {
         LLM();
     });
     function LLM() {
-        popupElement.style.display = "inline-block";
         const filename = fileObjects[currentIndex].path;
         // Check for file types using mime 
         //--------------------------------------------------------------------
@@ -643,7 +642,7 @@ window.onload = async function () {
             if (!fileContents || fileContents.length === 0) {
                 popupContentElement.textContent = "No file contents found.";
                 setTimeout(() => {
-                    popupContentElement.textContent = "Try another file buddy 😭";
+                    popupContentElement.textContent = "Please choose a file with contents.";
                 }, 4000);
                 return;
             }
@@ -683,6 +682,7 @@ window.onload = async function () {
                 })
                 .catch((error) => {
                     console.error("Error sending OpenAI request:", error);
+                    popupContentElement.textContent = "There was an error reading the contents. Please try again.";
                 });
         }
         // PDF & DOCX files
@@ -749,9 +749,11 @@ window.onload = async function () {
             // 86400000 24 hours
             // If 24 hours haven't passed and the image limit is reached, they cooked 
             if ((currentTime - loggedTime) <= 86400000 && imageLimit >= 2) {
-                popupContentElement.textContent = "You have reached the limit for the day.";
+                const timeLeft = convertMillisecondsToTimeLeft(86400000 - (currentTime - loggedTime));
+                console.log(timeLeft);
+                popupContentElement.textContent = "Your renaming limit for image files has been reached.";
                 setTimeout(() => {
-                    popupContentElement.textContent = "Try another file thats not an image fam 😭";
+                    popupContentElement.textContent = "You have " + timeLeft.hours + "h " + timeLeft.minutes + "m " + timeLeft.seconds + "s" + " left.";
                 }, 4000);
                 return;
             }
@@ -813,7 +815,7 @@ window.onload = async function () {
             console.log("Unsupported file type:", mimeType);
             popupContentElement.textContent = 'File type not supported.';
             setTimeout(() => {
-                popupContentElement.textContent = "Try another file buddy 😭";
+                popupContentElement.textContent = "I only support pdf, docx, jpeg, png, and txt files.";
             }, 4000);
             return;
         }
@@ -986,5 +988,20 @@ window.onload = async function () {
     // Reveal body after all elements are ready only for keep_or_delete.html
     if (document.body.classList.contains("keep-or-delete")) {
         document.body.classList.add("show");
+    }
+    function convertMillisecondsToTimeLeft(milliseconds) {
+        var seconds = Math.floor(milliseconds / 1000);
+        var minutes = Math.floor(seconds / 60);
+        var hours = Math.floor(minutes / 60);
+    
+        hours %= 24;
+        minutes %= 60;
+        seconds %= 60;
+    
+        return {
+            hours: hours,
+            minutes: minutes,
+            seconds: seconds
+        };
     }
 };

--- a/src/main_page/keep_or_delete.js
+++ b/src/main_page/keep_or_delete.js
@@ -95,33 +95,6 @@ window.onload = async function () {
             if (visible) resetTooltip();
         });
     }
-    // Progress Bar based on files left
-    const progress = document.getElementById("progress");
-    function updateProgress() {
-        const totalFiles = fileObjects.length;
-        const keptFiles = fileObjects.filter(f => f.status === "keep");
-        const filesToBeDeleted = fileObjects.filter(f => f.status === "delete");
-        const completedFiles = keptFiles.length + filesToBeDeleted.length;
-        const percent = totalFiles > 0 ? Math.round((completedFiles / totalFiles) * 100) : 0;
-        progress.style.width = `${percent}%`;
-        progress.textContent = percent + "%";
-
-        // Calculate total space saved
-        const totalSpaceSaved = filesToBeDeleted.reduce((sum, file) => sum + file.size, 0);
-
-        // Adding some glowing and scaling animation cause vibes.
-        if (percent === 100) {
-            progress.classList.add("complete");
-            saved.textContent = "You've saved: " + formatFileSize(totalSpaceSaved) + "!";
-            setTimeout(() => {
-                progress.classList.remove("complete");
-            }, 1000);
-        }
-        // Re-trigger the glowing animation
-        progress.classList.remove("glowing");
-        void progress.offsetWidth;
-        progress.classList.add("glowing");
-    }
     // Get stored file objects
     const storedObjects = JSON.parse(localStorage.getItem("fileObjects")) || [];
     //this stretch of code checks if we are navigating to this page from the final page from

--- a/src/main_page/keep_or_delete.js
+++ b/src/main_page/keep_or_delete.js
@@ -663,7 +663,7 @@ window.onload = async function () {
                             renameInputElement.classList.remove("glowing", "wiggle");
                         }, 500);
                     }
-                    popupContentElement.textContent = "Try Again!";
+                    popupContentElement.textContent = "Another suggestion?";
                 })
                 .catch((error) => {
                     console.error("Error sending OpenAI request:", error);
@@ -706,10 +706,11 @@ window.onload = async function () {
                                 renameInputElement.classList.remove("glowing", "wiggle");
                             }, 500);
                         }
-                        popupContentElement.textContent = "Try Again!";
+                        popupContentElement.textContent = "Another suggestion?";
                     })
                     .catch((error) => {
                         console.error("Error sending OpenAI request:", error);
+                        popupContentElement.textContent = "There was an error reading the contents. Please try again.";
                     });
             }
             pdfAIcall();
@@ -786,7 +787,7 @@ window.onload = async function () {
                                 renameInputElement.classList.remove("glowing", "wiggle");
                             }, 500);
                         }
-                        popupContentElement.textContent = "Try Again!";
+                        popupContentElement.textContent = "Another suggestion?";
                     })
                     .catch((error) => {
                         console.error("Error sending OpenAI request:", error);

--- a/src/main_page/keep_or_delete.js
+++ b/src/main_page/keep_or_delete.js
@@ -61,6 +61,7 @@ window.onload = async function () {
         if (hasFiles()) {
             displayCurrentFile();
         } else {
+            updateProgress();
             document.getElementById("currentItem").innerText = "No files found.";
         }
     }
@@ -949,10 +950,11 @@ window.onload = async function () {
     // Progress Bar based on files left
     function updateProgress() {
         const totalFiles = fileObjects.length;
-        const keptFiles = fileObjects.filter(f => f.status === "keep");
-        const filesToBeDeleted = fileObjects.filter(f => f.status === "delete");
-        const completedFiles = keptFiles.length + filesToBeDeleted.length;
-        const percent = totalFiles > 0 ? Math.round((completedFiles / totalFiles) * 100) : 0;
+        let percent;
+            const keptFiles = fileObjects.filter(f => f.status === "keep");
+            const filesToBeDeleted = fileObjects.filter(f => f.status === "delete");
+            const completedFiles = keptFiles.length + filesToBeDeleted.length;
+            percent = Math.round((completedFiles / totalFiles) * 100);
         progress.style.width = `${percent}%`;
         progress.textContent = percent + "%";
 
@@ -971,6 +973,18 @@ window.onload = async function () {
         progress.classList.remove("glowing");
         void progress.offsetWidth;
         progress.classList.add("glowing");
+
+        if (totalFiles === 0) {
+            // When there are no files, assume all work is done (100%)
+            percent = 100;
+            progress.classList.add("complete");
+            progress.style.width = `${percent}%`;
+            progress.textContent = percent + "%";
+            setTimeout(() => {
+                progress.classList.remove("complete");
+            }, 1000);
+            return;
+        }
     }
     // Reveal body after all elements are ready only for keep_or_delete.html
     if (document.body.classList.contains("keep-or-delete")) {

--- a/src/main_page/keep_or_delete.js
+++ b/src/main_page/keep_or_delete.js
@@ -285,7 +285,19 @@ window.onload = async function () {
     renameButton.addEventListener('click', async (event) => {
         if (!hasFiles()) return;
         renameModal.showModal();
-        popupContentElement.innerText = "AI Suggested Name"
+        const filename = fileObjects[currentIndex].name;
+        // If file is an image, show time left automatically
+        const mimeType = window.file.getMimeType(filename);
+        if(mimeType.startsWith("image/")){
+            if(LimitDisplay()){
+                const loggedTime = parseInt(localStorage.getItem("loggedTime") || "0", 10);
+                const timeLeft = convertMillisecondsToTimeLeft(86400000 - (Date.now() - loggedTime));
+                popupContentElement.textContent = timeLeft.hours + "h " + timeLeft.minutes + "m " + timeLeft.seconds + "s" + " left until I can suggest a name for images.";
+            }
+        }
+        else{
+            popupContentElement.innerText = "AI: Try me!"
+        } 
     });
 
     closeModal.addEventListener("click", () => {
@@ -678,7 +690,7 @@ window.onload = async function () {
                             renameInputElement.classList.remove("glowing", "wiggle");
                         }, 500);
                     }
-                    popupContentElement.textContent = "Get new AI Name";
+                    popupContentElement.textContent = "Try Again!";
                 })
                 .catch((error) => {
                     console.error("Error sending OpenAI request:", error);
@@ -721,7 +733,7 @@ window.onload = async function () {
                                 renameInputElement.classList.remove("glowing", "wiggle");
                             }, 500);
                         }
-                        popupContentElement.textContent = "Get new AI Name";
+                        popupContentElement.textContent = "Try Again!";
                     })
                     .catch((error) => {
                         console.error("Error sending OpenAI request:", error);
@@ -800,7 +812,7 @@ window.onload = async function () {
                                 renameInputElement.classList.remove("glowing", "wiggle");
                             }, 500);
                         }
-                        popupContentElement.textContent = "Get new AI Name";
+                        popupContentElement.textContent = "Try Again!";
                     })
                     .catch((error) => {
                         console.error("Error sending OpenAI request:", error);
@@ -1004,4 +1016,20 @@ window.onload = async function () {
             seconds: seconds
         };
     }
+    
+
+        function LimitDisplay() {
+            
+            const currentTime = Date.now();
+            // Get the image limit and logged time from local storage
+            let imageLimit = parseInt(localStorage.getItem("imageLimit") || "0", 10);
+            let loggedTime = parseInt(localStorage.getItem("loggedTime") || "0", 10);
+            
+            // Check if the limit has been reached
+            if ((currentTime - loggedTime) <= 86400000 && imageLimit >= 2) {
+                return true;
+            }
+            return false;  
+        }
+
 };

--- a/src/main_page/keep_or_delete.js
+++ b/src/main_page/keep_or_delete.js
@@ -291,7 +291,7 @@ window.onload = async function () {
         if(mimeType.startsWith("image/")){
             if(LimitDisplay()){
                 const loggedTime = parseInt(localStorage.getItem("loggedTime") || "0", 10);
-                const timeLeft = convertMillisecondsToTimeLeft(86400000 - (Date.now() - loggedTime));
+                const timeLeft = convertMillisecondsToTimeLeft(14400000 - (Date.now() - loggedTime));
                 popupContentElement.textContent = timeLeft.hours + "h " + timeLeft.minutes + "m " + timeLeft.seconds + "s" + " left until I can suggest a name for images.";
             }
         }
@@ -750,7 +750,7 @@ window.onload = async function () {
             let loggedTime = parseInt(localStorage.getItem("loggedTime") || "0", 10);
 
             //reset the counter if 24 hours have passed
-            if (currentTime - loggedTime > 86400000) {
+            if (currentTime - loggedTime > 14400000) {
                 imageLimit = 0;
                 loggedTime = currentTime;
                 localStorage.setItem("imageLimit", imageLimit);
@@ -759,9 +759,10 @@ window.onload = async function () {
 
             // 60000 minute
             // 86400000 24 hours
-            // If 24 hours haven't passed and the image limit is reached, they cooked 
-            if ((currentTime - loggedTime) <= 86400000 && imageLimit >= 2) {
-                const timeLeft = convertMillisecondsToTimeLeft(86400000 - (currentTime - loggedTime));
+            // 14400000 4 hours
+            // If 4 hours haven't passed and the image limit is reached, they cooked 
+            if ((currentTime - loggedTime) <= 14400000 && imageLimit >= 2) {
+                const timeLeft = convertMillisecondsToTimeLeft(14400000 - (currentTime - loggedTime));
                 console.log(timeLeft);
                 popupContentElement.textContent = "Your renaming limit for image files has been reached.";
                 setTimeout(() => {
@@ -1016,8 +1017,6 @@ window.onload = async function () {
             seconds: seconds
         };
     }
-    
-
         function LimitDisplay() {
             
             const currentTime = Date.now();
@@ -1026,7 +1025,7 @@ window.onload = async function () {
             let loggedTime = parseInt(localStorage.getItem("loggedTime") || "0", 10);
             
             // Check if the limit has been reached
-            if ((currentTime - loggedTime) <= 86400000 && imageLimit >= 2) {
+            if ((currentTime - loggedTime) <= 14400000 && imageLimit >= 2) {
                 return true;
             }
             return false;  

--- a/test/ai-rename.test.js
+++ b/test/ai-rename.test.js
@@ -152,7 +152,7 @@ test("Image renaming limit prevents additional processing", async () => {
   await window.click("#renameButton");
   await window.click("#popupContent");
   const popupContentText = await window.locator("#popupContent").innerText();
-  await expect(popupContentText).toContain("reached the limit");
+  await expect(popupContentText).toContain("limit for image files has been reached");
 
   // Verify that the imageLimit remains at "2" in localStorage.
   const imageLimitStored = await window.evaluate(() =>


### PR DESCRIPTION
## Polishing
This pull request cleans up some redundant functions, polishes AI responses and fixes progress bar. 

## Changes
- Added message to show user how much time left on image remaining 
- Changing log time to 4 hours
- Set PDF parsing limit for large files
- Make sure every error has a response 
- Progress bar hot-fix

## Why?
- To optimize and polish features for final presentation

## Misc Bug
- Progress bar (bug?) once progress hits 100% and the user goes to another page like settings. When you navigate back to main page that bar is not loaded. This is due to the hasfiles() method in ```line 61``` where after a directory is fully sorted it returns false. This dictates whether the displayCurrentfile() is called which has updateProgress() nested. I found a work around to this. However, do you guys want the progress bar to say 100 after everything is sorted or stay empty?

## Example 
<img width="1470" alt="Screenshot 2025-04-03 at 5 28 37 PM" src="https://github.com/user-attachments/assets/b3deee8d-43bf-40cf-84e8-609416252b4e" />

